### PR TITLE
Import parsing replacement

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "clone": "^0.1.17",
     "find-file": "^0.1.4",
     "parse-import": "^0.1.3",
-    "postcss": "^2.1.0"
+    "postcss": "^2.1.0",
+    "postcss-helpers": "0.2.0"
   },
   "devDependencies": {
     "css-whitespace": "^1.1.0",


### PR DESCRIPTION
Completely optional pull-request. Feel free to ignore it. 

I replaced "parse-import" with "postcss-helpers" and updated places where it is called to make working with import rules more straightforward:
1. RegExp in `postcss-helpers` is more in line with http://www.w3.org/TR/CSS21/grammar.html and returns more clean media queries (for example it removes \n symbols from beginning and the end of the string, than they are used as separator). See https://github.com/iAdramelk/postcss-helpers/blob/master/lib/regexp.js vs https://github.com/kevva/parse-import/blob/master/index.js
2. You don't need to add `@import` to parse it anymore.
3. Replaced `parsedAtImport.path.match(/[a-z]+:\/\//i)` with parsedAtImport.URI.is("absolute") to also detect urls that are starting with `//`.
4. Replaced `parsedAtImport.path` to `parsedAtImport.URI.path()` because it returns path without `#` and `?` segments that can be used to set version numbers.
