### PR TITLE
Add a test for relative import without from option

### DIFF
--- a/test/fixtures/imports/relative/import.css
+++ b/test/fixtures/imports/relative/import.css
@@ -1,0 +1,1 @@
+@import "../bar.css";

--- a/test/index.js
+++ b/test/index.js
@@ -107,3 +107,12 @@ test("@import callback", function(t) {
       from: "./test/fixtures/recursive.css"
     })
 })
+
+test("import relative files without from option in postcss.process", function(t) {
+  postcss()
+    .use(atImport({
+      path: "test/fixtures/imports/relative"
+    }))
+    .process(read("fixtures/imports/relative/import"))
+  t.end()
+})


### PR DESCRIPTION
This PR adds a test that fails. I found that it could be a `resolve` package issue, so that's why I do that. It's a start.

I found that the problem appears (at least) when a path starts with `../` because `resolve` doesn't use `paths` array in that case, it tries to resolve with `basedir` and fails.

Try replacing this test in `lib/sync.js` from `resolve` package (line 21-29):
```javascript
if (/^(?:\.\.?(?:\/|$)|\/|([A-Za-z]:)?[\\\/])/.test(x)) {
        var res = y;
        for (var i = opts.paths.length - 1; i >= 0; i--) {
            if (path.resolve(y, opts.paths[i])) {
                res = path.resolve(y, opts.paths[i]);
                break;
            }
        };
        res = path.resolve(res, x);
        if (x === '..') res += '/';
        var m = loadAsFileSync(res) || loadAsDirectorySync(res);
        if (m) return m;
    } else {
        var n = loadNodeModulesSync(x, y);
        if (n) return n;
    }
```

Still don't know if it's a bug in resolve, or if it's a feature. Any thought ?


(ref #14)