### PR TITLE
Create `before` property on `first` element, only if defined

### DIFF
--- a/index.js
+++ b/index.js
@@ -109,7 +109,9 @@ function addIgnoredAtRulesOnTop(styles, ignoredAtRules) {
       styles.nodes.unshift(ignoredAtRule)
     }
 
-    first.before = "\n\n" + first.before
+    if (first) {
+      first.before = "\n\n" + first.before
+    }
   }
 }
 

--- a/test/index.js
+++ b/test/index.js
@@ -53,6 +53,16 @@ test("@import", function(t) {
 
   compareFixtures(t, "modules", "should be able to consume npm package or local modules", {root: __dirname, path: importsDir})
 
+  var base = "@import url(http://)"
+  t.equal(
+    postcss()
+      .use(atImport())
+      .process(base)
+      .css.trim(),
+      base,
+      "should not fail with only one absolute import"
+  )
+
   t.end()
 })
 


### PR DESCRIPTION
It fixes #22, but as there is no comment, I don't know why you try to clone `before` with `\n\n`