### PR TITLE
Remove unnecessary if requirements

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,7 +41,7 @@ function AtImport(options) {
 
   return function(styles) {
     // auto add from option if possible
-    if (!options.from && styles && styles.nodes && styles.nodes[0] && styles.nodes[0].source && styles.nodes[0].source.input && styles.nodes[0].source.input.file) {
+    if (!options.from && styles.nodes[0].source.input.file) {
       options.from = styles.nodes[0].source.input.file
     }
 


### PR DESCRIPTION
It's unnecessary to check if `styles` existing and all it props separately to `styles.nodes[0].source.input.file`. If `style` will not exist so it already except the `if` statement