### PR TITLE
Ensure glob works when using single quotes and/or url(path)

### DIFF
--- a/index.js
+++ b/index.js
@@ -108,7 +108,7 @@ function parseStyles(styles, options, cb, importedFiles, ignoredAtRules, media, 
  * @param {Array} imports
  */
 function parseGlob(atRule, options, imports) {
-  var globPattern = atRule.params.replace(/"/g, "")
+  var globPattern = atRule.params.replace(/['"]/g, "").replace(/(?:url\(|\))/g, "")
   var files = []
   var dir = options.source && options.source.input && options.source.input.file ?
     path.dirname(path.resolve(options.root, options.source.input.file)) :

--- a/test/fixtures/glob-alt.css
+++ b/test/fixtures/glob-alt.css
@@ -1,0 +1,1 @@
+@import url('./foobar*.css');

--- a/test/fixtures/glob-alt.expected.css
+++ b/test/fixtures/glob-alt.expected.css
@@ -1,0 +1,2 @@
+foobar{}
+foobarbaz{}

--- a/test/index.js
+++ b/test/index.js
@@ -41,6 +41,10 @@ test("@import", function(t) {
     glob: true
   })
 
+  compareFixtures(t, "glob-alt", "should handle a glob pattern with single quote and/or url(...)", {
+    path: importsDir,
+    glob: true
+  })
   compareFixtures(t, "recursive", "should import stylsheets recursively")
 
   compareFixtures(t, "relative", "should import stylsheets relatively")


### PR DESCRIPTION
Sorry, my previous PR only accounted for @import rules with double quotes. This commit ensures that globs work when the @import uses single quotes and/or the url(path) syntax. Added a test for it, too.