### PR TITLE
Make globbed imports work for module directories, too.

### DIFF
--- a/index.js
+++ b/index.js
@@ -109,11 +109,12 @@ function parseStyles(styles, options, cb, importedFiles, ignoredAtRules, media, 
  */
 function parseGlob(atRule, options, imports) {
   var globPattern = atRule.params.replace(/['"]/g, "").replace(/(?:url\(|\))/g, "")
+  var paths = options.path.concat(moduleDirectories)
   var files = []
   var dir = options.source && options.source.input && options.source.input.file ?
     path.dirname(path.resolve(options.root, options.source.input.file)) :
     options.root
-  options.path.forEach(function(p) {
+  paths.forEach(function(p) {
     p = path.resolve(dir, p)
     var globbed = glob.sync(path.join(p, globPattern))
     globbed.forEach(function(file) {

--- a/test/fixtures/glob.css
+++ b/test/fixtures/glob.css
@@ -1,1 +1,2 @@
 @import "./foobar*.css";
+@import "by-hand/*.css";

--- a/test/fixtures/glob.expected.css
+++ b/test/fixtures/glob.expected.css
@@ -1,2 +1,3 @@
 foobar{}
 foobarbaz{}
+.byHand{}

--- a/test/index.js
+++ b/test/index.js
@@ -37,6 +37,7 @@ test("@import", function(t) {
   compareFixtures(t, "ignore", "should ignore & adjust external import")
 
   compareFixtures(t, "glob", "should handle a glob pattern", {
+    root: __dirname,
     path: importsDir,
     glob: true
   })


### PR DESCRIPTION
Concatenated `moduleDirectories` to paths for globbed @import rules and modified the glob test to make sure it works. Wish I had noticed this the first time around. Anyway, this PR should be the last for the glob option. Thanks for merging these in so quickly. Really appreciate it!