### PR TITLE
Fix warnings

### DIFF
--- a/index.js
+++ b/index.js
@@ -380,9 +380,7 @@ function readImportedContent(
     .then(function() {
       return processor.process(newStyles)
         .then(function(newResult) {
-          newResult.warnings().forEach(function(message) {
-            result.warn(message)
-          })
+          result.messages = result.messages.concat(newResult.messages)
         })
     })
     .then(function() {


### PR DESCRIPTION
In reference to https://github.com/postcss/postcss-import/pull/55#issuecomment-113618351:

@MoOx you're right! I was getting warnings like this:
```
page2.css postcss-bem-linter: styles\blocks\block-bar.css:11:5: Invalid component
selector ".block-bar__element" [cssnext]
```
But this PR gives me much better warnings, like the following:
```
page2.css
11:5    Invalid component selector ".block-bar__element" [postcss-bem-linter]
```
Not quite sure how to add the proper tests, but I thought you could at least use a little help here.