### PR TITLE
Fix plugins section of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ A function to transform the content of imported files. Take one argument (file c
 
 #### `plugins`
 
-Type: `Array`
+Type: `Array`  
 Default: `undefined`
 
 An array of plugins to be applied on each imported file.


### PR DESCRIPTION
The `Default` part to the plugins option was on the same line as the Type. Simple fix here.