### PR TITLE
add options.cache to save file io

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,13 @@ It's to optimize output and skip similar files like `normalize.css` for example.
 If this behavior is not what you want, just set this option to `false` to
 disable it.
 
+#### `cache`
+
+Type: `Object`  
+Default: `null`
+
+Cache to save expensive file io. It maps the resolved file name to the corresponding transformed file contents (`String`).
+
 #### Example with some options
 
 ```js

--- a/index.js
+++ b/index.js
@@ -74,6 +74,7 @@ function AtImport(options) {
       importedFiles: {},
       ignoredAtRules: [],
       hashFiles: {},
+      cache: options.cache || {},
     }
     if (opts.from) {
       state.importedFiles[opts.from] = {
@@ -347,7 +348,8 @@ function readImportedContent(
     options.encoding,
     options.transform || function(value) {
       return value
-    }
+    },
+    state.cache
   )
 
   if (fileContent.trim() === "") {
@@ -537,8 +539,11 @@ function resolveFilename(name, root, paths, source, resolver) {
  *
  * @param {String} file
  */
-function readFile(file, encoding, transform) {
-  return transform(fs.readFileSync(file, encoding || "utf8"), file)
+function readFile(file, encoding, transform, cache) {
+  if (!cache[file]) {
+    cache[file] = transform(fs.readFileSync(file, encoding || "utf8"), file)
+  }
+  return cache[file]
 }
 
 /**

--- a/test/index.js
+++ b/test/index.js
@@ -345,3 +345,23 @@ test("sync", function(t) {
 
   t.end()
 })
+
+test("cache option", function(t) {
+  t.plan(1)
+
+  postcss()
+    .use(atImport({
+      resolve: function(file) {
+        return path.basename(file)
+      },
+      cache: {
+        b: ".b{}",
+        c: "@import '/d';.c{}",
+        d: ".d{}",
+      },
+    }))
+    .process("@import '/c';@import '/b';.a{}")
+    .then(function(res) {
+      t.equal(res.css, ".d{}.c{}.b{}.a{}")
+    })
+})


### PR DESCRIPTION
I'm using postcss to split css into modules, and postcss-import plays a great role. As there are increasingly many css files to generate, some common modules imported may have to be read many times, which makes the performance worse and worse.

Suppose there are two files to compile:

`a.css`

```css
@import "mixins.css";
.a{}
```

`b.css`

```css
@import "mixins.css";
.b{}
```

It seems that `mixins.css` will be read twice.

I think `options.cache` is able to fix that problem, by caching the transformed file contents and sharing it globally.

Moreover, if the `cache` is manipulatable externally, some file watching tools (like [watchify](https://www.npmjs.com/package/watchify) ) can also work with postcss easily.

I see https://github.com/postcss/postcss-import/pull/47 handles in some way. But that pr has failing checks.

What are your opinions?