### PR TITLE
Stop cloning options for a massive performance boost

### DIFF
--- a/index.js
+++ b/index.js
@@ -314,7 +314,7 @@ function readAtImport(
     result,
     atRule,
     parsedAtImport,
-    options,
+    Object.create(options),
     resolvedFilename,
     state,
     media,

--- a/index.js
+++ b/index.js
@@ -5,7 +5,6 @@ var fs = require("fs")
 var path = require("path")
 
 var assign = require("object-assign")
-var clone = require("clone")
 var resolve = require("resolve")
 var postcss = require("postcss")
 var helpers = require("postcss-message-helpers")
@@ -315,7 +314,7 @@ function readAtImport(
     result,
     atRule,
     parsedAtImport,
-    clone(options),
+    options,
     resolvedFilename,
     state,
     media,

--- a/index.js
+++ b/index.js
@@ -314,7 +314,7 @@ function readAtImport(
     result,
     atRule,
     parsedAtImport,
-    Object.create(options),
+    Object.assign({}, options),
     resolvedFilename,
     state,
     media,

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "index.js"
   ],
   "dependencies": {
-    "clone": "^1.0.2",
     "glob": "^5.0.14",
     "object-assign": "^4.0.1",
     "postcss": "^5.0.2",


### PR DESCRIPTION
This seemingly innocent operation is apparently responsible for
some serious performance bottlenecks. In testing, I've seen that
performance degrades by nearly an order of magnitute per file
imported. By not cloning options, this bottleneck goes away,
making this plugin significantly faster.

On a project with 9 `@import` rules running this plugin took on
average 7 seconds; by removing this clone operation it now takes
on average 100ms, with roughly 90% of that time spent in file I/O.