### PR TITLE
Remove unnecessary glob-alt test

### DIFF
--- a/test/fixtures/glob-alt.css
+++ b/test/fixtures/glob-alt.css
@@ -1,1 +1,0 @@
-@import url('./foobar*.css');

--- a/test/fixtures/glob-alt.expected.css
+++ b/test/fixtures/glob-alt.expected.css
@@ -1,2 +1,0 @@
-foobar{}
-foobarbaz{}

--- a/test/glob.js
+++ b/test/glob.js
@@ -5,13 +5,6 @@ import glob from "glob"
 
 test("should handle a glob pattern", t => {
   return compareFixtures(t, "glob", {
-    root: ".",
-    glob: true,
-  })
-})
-
-test("should handle a glob pattern with single quote and/or url(...)", t => {
-  return compareFixtures(t, "glob-alt", {
     glob: true,
   })
 })


### PR DESCRIPTION
resolver response for globs. They use the same parser as regular uris