### PR TITLE
Simple glob resolver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ See [resolve option](https://github.com/postcss/postcss-import#resolve) for more
 ([#120](https://github.com/postcss/postcss-import/pull/120))
 - Changed: custom resolve should include glob resolver
 ([#121](https://github.com/postcss/postcss-import/pull/121))
+- Changed: glob resolver do not add `moduleDirectories` and parse all uri as glob patterns
 
 # 7.1.3 - 2015-11-05
 

--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ Type: `Boolean`
 Default: `false`
 
 Set to `true` if you want @import rules to parse glob patterns.
+Files will be searched in base directory and paths specified in `path` option.
 
 #### `resolve`
 

--- a/lib/resolve-id.js
+++ b/lib/resolve-id.js
@@ -1,6 +1,6 @@
 var fs = require("fs")
 var path = require("path")
-var glob = require("glob")
+var globby = require("globby")
 var resolve = require("resolve")
 
 var moduleDirectories = [
@@ -33,31 +33,12 @@ function resolveModule(id, opts) {
   })
 }
 
-function resolveGlob(patterns) {
-  var files = []
-  var promises = patterns.map(function(pattern) {
-    return new Promise(function(resolve, reject) {
-      glob(pattern, function(err, result) {
-        if (err) {
-          return reject(err)
-        }
-        files = files.concat(result)
-        resolve()
-      })
-    })
-  })
-  return Promise.all(promises).then(function() {
-    return files
-  })
-}
-
 module.exports = function(id, base, options) {
   var paths = options.path
 
-  if (options.glob && glob.hasMagic(id)) {
-    // Remove moduleDirectories from paths
-    paths = [ base ].concat(paths, moduleDirectories)
-    return resolveGlob(paths.map(function(p) {
+  if (options.glob) {
+    paths = [ base ].concat(paths)
+    return globby(paths.map(function(p) {
       return path.resolve(p, id)
     }))
   }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "index.js"
   ],
   "dependencies": {
-    "glob": "^5.0.14",
+    "globby": "^4.0.0",
     "object-assign": "^4.0.1",
     "postcss": "^5.0.2",
     "postcss-value-parser": "^3.2.3",

--- a/test/glob.js
+++ b/test/glob.js
@@ -1,10 +1,15 @@
 import test from "ava"
 import compareFixtures from "./lib/compare-fixtures"
 import path from "path"
-import glob from "glob"
+import globby from "globby"
 
 test("should handle a glob pattern", t => {
   return compareFixtures(t, "glob", {
+    path: [
+      "fixtures/imports",
+      "node_modules",
+      "web_modules",
+    ],
     glob: true,
   })
 })
@@ -28,7 +33,7 @@ test("should fail silently, skipping the globbed import," +
 test("should handle a glob by custom resolver", t => {
   return compareFixtures(t, "glob-resolve", {
     resolve: (id, base) => {
-      return glob.sync(path.resolve(base, id))
+      return globby.sync(path.resolve(base, id))
     },
   }, {
     from: "fixtures/glob-resolve.css",


### PR DESCRIPTION
`moduleDirectories` shound't be used caz they do not give any resolving benefits and can just confuse. Better give ability to add it to path.
Also all resolvings should be consistent with enabled `glob`, so non-glob imports should also be resolved as glob.