### PR TITLE
Support running PostCSS-import via JSPM in browser environment

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,5 +39,11 @@
   },
   "eslintConfig": {
     "extends": "eslint-config-i-am-meticulous/es5"
+  },
+  "jspm": {
+    "browser": {
+      "./lib/load-content": "@empty",
+      "./lib/resolve-id": "@empty"
+    }
   }
 }


### PR DESCRIPTION
By adding an entry to package.json which is jspm-specific we allow PostCSS-import to be utilized by JSPM in browser environments.

The `load-content` module has node-specific deps. (mentioned here: https://github.com/postcss/postcss-import/issues/181). As such, it should be prevented from being loaded in browser environments in favor of specifying a custom `load` via options.