### PR TITLE
Add JSPM browser field

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,5 +39,11 @@
   },
   "eslintConfig": {
     "extends": "eslint-config-i-am-meticulous/es5"
+  },
+  "jspm": {
+    "browser": {
+      "./lib/load-content": "@empty",
+      "./lib/resolve-id": "@empty"
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -42,10 +42,8 @@
   },
   "jspm": {
     "browser": {
-      "map": {
-        "./lib/load-content": "@empty",
-        "./lib/resolve-id": "@empty"
-      }
+      "./lib/load-content": "@empty",
+      "./lib/resolve-id": "@empty"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -42,8 +42,10 @@
   },
   "jspm": {
     "browser": {
-      "./lib/load-content": "@empty",
-      "./lib/resolve-id": "@empty"
+      "map": {
+        "./lib/load-content": "@empty",
+        "./lib/resolve-id": "@empty"
+      }
     }
   }
 }


### PR DESCRIPTION
Add @empty statements for load-content and resolve-id so that their deps aren't loaded in browser environment. This allows for JSPM to not error out. Custom resolve/load functions will need to be provided as options for proper functionality.

(New PR cuz I'm a terrible Git wizard and failed to squash properly after a few attempts.)