### PR TITLE
Improved tolerancy for failed imports of jspm-chain. See issue #198. Works around https://github.com/jspm/jspm-cli/pull/1779 stuntil that is fixed.

### DIFF
--- a/lib/resolve-id.js
+++ b/lib/resolve-id.js
@@ -1,5 +1,11 @@
 var resolve = require("resolve")
-var jspmResolve = require("pkg-resolve")
+var jspmResolve
+try {
+  jspmResolve = require("pkg-resolve")
+}
+catch (ex) {
+  // pass
+}
 
 var moduleDirectories = [
   "web_modules",


### PR DESCRIPTION
Clean PR of previous fix