### PR TITLE
Fix tests

### DIFF
--- a/index.js
+++ b/index.js
@@ -164,7 +164,7 @@ function parseStyles(
   var statements = parseStatements(result, styles)
 
   return Promise.all(statements.map(function(stmt) {
-    stmt.media = joinMedia(media, stmt.media)
+    stmt.media = joinMedia(media, stmt.media || [])
 
     // skip protocol base uri (protocol://url) or protocol-relative
     if (stmt.type !== "import" || /^(?:[a-z]+:)?\/\//i.test(stmt.uri)) {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "resolve": "^1.1.7"
   },
   "devDependencies": {
-    "ava": "^0.11.0",
+    "ava": "^0.16.0",
     "eslint": "^1.10.3",
     "eslint-config-i-am-meticulous": "^2.0.0",
     "npmpub": "^3.0.1",

--- a/test/callback.js
+++ b/test/callback.js
@@ -10,7 +10,7 @@ test("should have a callback that returns an object" +
     .use(atImport({
       path: "fixtures/imports",
       onImport: files => {
-        t.same(
+        t.deepEqual(
           files,
           [
             resolve("fixtures/media-import.css"),
@@ -42,7 +42,7 @@ test("should have a callback shortcut for webpack", t => {
       from: "fixtures/media-import.css",
     })
     .then(() => {
-      t.same(
+      t.deepEqual(
         files,
         [
           resolve("fixtures/media-import.css"),

--- a/test/plugins.js
+++ b/test/plugins.js
@@ -28,8 +28,8 @@ test("should apply plugins to root", t => {
     ],
   })
   .then(() => {
-    t.same(atRules, [ "import" ])
-    t.same(rules, [ "bar", "foo" ])
+    t.deepEqual(atRules, [ "import" ])
+    t.deepEqual(rules, [ "bar", "foo" ])
   })
 })
 


### PR DESCRIPTION
This gets the tests running again, and also updates to the latest version of Ava. The issue seemed to be related to the media property not being set to an empty array by default.