### PR TITLE
BREAKING: Remove pkg-resolve as a dep

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,13 @@ postcss()
   })
 ```
 
+### jspm Usage
+
+postcss-import can `@import` [jspm](http://jspm.io) dependencies if
+[`pkg-resolve`](https://www.npmjs.com/package/pkg-resolve) is installed by the
+user. Run `npm install pkg-resolve` to install it. postcss-import should then be
+able to import from jspm dependencies without further configuration.
+
 ---
 
 ## CONTRIBUTING

--- a/package.json
+++ b/package.json
@@ -32,9 +32,6 @@
     "npmpub": "^3.0.1",
     "postcss-scss": "^0.1.3"
   },
-  "optionalDependencies": {
-    "pkg-resolve": "^0.1.7"
-  },
   "jspm": {
     "name": "postcss-import",
     "main": "index.js",


### PR DESCRIPTION
Users can still install it manually if they need the functionality.

Fixes https://github.com/postcss/postcss-import/issues/212.

@MoOx Do the docs look good?

Note that this PR is against the `v9-dev` branch, not `master`. All future PRs aimed for v9 should be made against that branch.