### PR TITLE
Play well with Custom Syntax

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ var postcss = require("postcss")
 var joinMedia = require("./lib/join-media")
 var resolveId = require("./lib/resolve-id")
 var loadContent = require("./lib/load-content")
+var processContent = require("./lib/process-content")
 var parseStatements = require("./lib/parse-statements")
 var promiseEach = require("promise-each")
 
@@ -314,11 +315,12 @@ function loadImportContent(
       return
     }
 
-    return postcss(options.plugins).process(content, {
-      from: filename,
-      syntax: result.opts.syntax,
-      parser: result.opts.parser,
-    })
+    return processContent(
+      result,
+      content,
+      filename,
+      options
+    )
     .then(function(importedResult) {
       var styles = importedResult.root
       result.messages = result.messages.concat(importedResult.messages)

--- a/lib/process-content.js
+++ b/lib/process-content.js
@@ -1,0 +1,61 @@
+var path = require("path")
+var postcss = require("postcss")
+var sugarss
+
+module.exports = function processContent(
+  result,
+  content,
+  filename,
+  options
+) {
+  var plugins = options.plugins
+  var ext = path.extname(filename)
+
+  var parserList = []
+
+  // SugarSS support:
+  if (ext === ".sss") {
+    if (!sugarss) {
+      try {
+        sugarss = require("sugarss")
+      }
+      catch (e) {
+        // Ignore
+      }
+    }
+    if (sugarss) return runPostcss(content, filename, plugins, [ sugarss ])
+  }
+
+  // Syntax support:
+  if (result.opts.syntax && result.opts.syntax.parse) {
+    parserList.push(result.opts.syntax.parse)
+  }
+
+  // Parser support:
+  if (result.opts.parser) parserList.push(result.opts.parser)
+  // Try the default as a last resort:
+  parserList.push(null)
+
+  return runPostcss(content, filename, plugins, parserList)
+}
+
+function runPostcss(
+  content,
+  filename,
+  plugins,
+  parsers,
+  index
+) {
+  if (!index) index = 0
+  return postcss(plugins).process(content, {
+    from: filename,
+    parser: parsers[index],
+  })
+  .catch(function(err) {
+    // If there's an error, try the next parser
+    index++
+    // If there are no parsers left, throw it
+    if (index === parsers.length) throw err
+    return runPostcss(content, filename, plugins, parsers, index)
+  })
+}

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "eslint": "^1.10.3",
     "eslint-config-i-am-meticulous": "^2.0.0",
     "npmpub": "^3.0.1",
-    "postcss-scss": "^0.1.3"
+    "postcss-scss": "^0.1.3",
+    "sugarss": "^0.2.0"
   },
   "jspm": {
     "name": "postcss-import",

--- a/test/custom-syntax-parser.js
+++ b/test/custom-syntax-parser.js
@@ -1,6 +1,8 @@
 import test from "ava"
 import scss from "postcss-scss"
+import sugarss from "sugarss"
 import compareFixtures from "./helpers/compare-fixtures"
+import compareFixturesExt from "./helpers/compare-fixtures-ext"
 
 test("should process custom syntax", t => {
   return compareFixtures(t, "scss-syntax", null, {
@@ -11,5 +13,31 @@ test("should process custom syntax", t => {
 test("should process custom syntax by parser", t => {
   return compareFixtures(t, "scss-parser", null, {
     parser: scss,
+  })
+})
+
+test(".css importing .sss should work", t => {
+  return compareFixtures(t, "import-sss")
+})
+
+test(".sss importing .sss should work", t => {
+  return compareFixturesExt(t, "sugar", ".sss", null, {
+    parser: sugarss,
+  })
+})
+
+test(".sss importing .css should work", t => {
+  return compareFixturesExt(t, "sugar-import-css", ".sss", null, {
+    parser: sugarss,
+  })
+})
+
+test(".css importing .sss importing .css should work", t => {
+  return compareFixtures(t, "import-sss-css")
+})
+
+test(".sss importing .css importing .sss should work", t => {
+  return compareFixturesExt(t, "import-css-sss", ".sss", null, {
+    parser: sugarss,
   })
 })

--- a/test/custom-syntax-parser.js
+++ b/test/custom-syntax-parser.js
@@ -1,0 +1,15 @@
+import test from "ava"
+import scss from "postcss-scss"
+import compareFixtures from "./helpers/compare-fixtures"
+
+test("should process custom syntax", t => {
+  return compareFixtures(t, "scss-syntax", null, {
+    syntax: scss,
+  })
+})
+
+test("should process custom syntax by parser", t => {
+  return compareFixtures(t, "scss-parser", null, {
+    parser: scss,
+  })
+})

--- a/test/fixtures/import-css-sss.expected.css
+++ b/test/fixtures/import-css-sss.expected.css
@@ -1,0 +1,9 @@
+.sugarbar{
+  color: blue
+}
+
+import.sugarbar{}
+
+.sugar{
+  color: white
+}

--- a/test/fixtures/import-css-sss.sss
+++ b/test/fixtures/import-css-sss.sss
@@ -1,0 +1,4 @@
+@import "import-sugarbar.css"
+
+.sugar
+  color: white

--- a/test/fixtures/import-sss-css.css
+++ b/test/fixtures/import-sss-css.css
@@ -1,0 +1,1 @@
+@import "foo-recursive.sss";

--- a/test/fixtures/import-sss-css.expected.css
+++ b/test/fixtures/import-sss-css.expected.css
@@ -1,0 +1,5 @@
+bar{}
+
+foo.recursive{
+  color: red
+}

--- a/test/fixtures/import-sss.css
+++ b/test/fixtures/import-sss.css
@@ -1,0 +1,1 @@
+@import "sugarbar.sss";

--- a/test/fixtures/import-sss.expected.css
+++ b/test/fixtures/import-sss.expected.css
@@ -1,0 +1,3 @@
+.sugarbar {
+  color: blue
+}

--- a/test/fixtures/imports/foo-recursive.sss
+++ b/test/fixtures/imports/foo-recursive.sss
@@ -1,0 +1,4 @@
+@import "bar.css"
+
+foo.recursive
+  color: red

--- a/test/fixtures/imports/import-sugarbar.css
+++ b/test/fixtures/imports/import-sugarbar.css
@@ -1,0 +1,3 @@
+@import "sugarbar.sss";
+
+import.sugarbar{}

--- a/test/fixtures/imports/sugarbar.sss
+++ b/test/fixtures/imports/sugarbar.sss
@@ -1,0 +1,2 @@
+.sugarbar
+  color: blue

--- a/test/fixtures/sugar-import-css.expected.css
+++ b/test/fixtures/sugar-import-css.expected.css
@@ -1,0 +1,4 @@
+bar{}
+.sugar{
+  color: white
+}

--- a/test/fixtures/sugar-import-css.sss
+++ b/test/fixtures/sugar-import-css.sss
@@ -1,0 +1,3 @@
+@import "bar.css"
+.sugar
+  color: white

--- a/test/fixtures/sugar.expected.css
+++ b/test/fixtures/sugar.expected.css
@@ -1,0 +1,6 @@
+.sugarbar {
+  color: blue
+}
+.sugar {
+  color: white
+}

--- a/test/fixtures/sugar.sss
+++ b/test/fixtures/sugar.sss
@@ -1,0 +1,3 @@
+@import "sugarbar.sss"
+.sugar
+  color: white

--- a/test/helpers/compare-fixtures-ext.js
+++ b/test/helpers/compare-fixtures-ext.js
@@ -1,0 +1,32 @@
+var fs = require("fs")
+var postcss = require("postcss")
+var assign = require("object-assign")
+var atImport = require("../..")
+
+function read(name, ext) {
+  if (!ext) ext = ".css"
+  return fs.readFileSync("fixtures/" + name + ext, "utf8")
+}
+
+module.exports = function(t, name, ext, opts, postcssOpts, warnings) {
+  opts = assign({ path: "fixtures/imports" }, opts)
+  return postcss(atImport(opts))
+    .process(read(name, ext), postcssOpts || {})
+    .then(function(result) {
+      var actual = result.css
+      var expected = read(name + ".expected")
+      // handy thing: checkout actual in the *.actual.css file
+      fs.writeFile("fixtures/" + name + ".actual.css", actual)
+      t.is(actual, expected)
+      if (!warnings) {
+        warnings = []
+      }
+      result.warnings().forEach(function(warning, index) {
+        t.is(
+          warning.text,
+          warnings[index],
+          "unexpected warning: \"" + warning.text + "\""
+        )
+      })
+    })
+}

--- a/test/plugins.js
+++ b/test/plugins.js
@@ -1,6 +1,5 @@
 import test from "ava"
 import postcss from "postcss"
-import scss from "postcss-scss"
 import atImport from ".."
 import compareFixtures from "./helpers/compare-fixtures"
 
@@ -50,16 +49,4 @@ test("should remain silent when value is an empty array", () => {
       plugins: [],
     }))
     .process("")
-})
-
-test("should process custom syntax", t => {
-  return compareFixtures(t, "scss-syntax", null, {
-    syntax: scss,
-  })
-})
-
-test("should process custom syntax by parser", t => {
-  return compareFixtures(t, "scss-parser", null, {
-    parser: scss,
-  })
 })


### PR DESCRIPTION
This is still a WIP. Will most likely need rebased when I'm done.

---

_Warning: This is a weird approach to solving this problem._

Perhaps this approach is naive; but it should be pretty well bulletproof. It is based on the (correct :stuck_out_tongue: ) assumption that if a parser can parse the input, it is the correct parser.

If the file is `.sss`, it tries that parser first. For all other files (or if SugarSS parsing fails) it tries the user-passed parser (if available). If that fails, it tries the default parser.

The reason I chose this approach is that we have no reliable way of telling if `result.opts.parser` is a CSS-compliant parser. See https://github.com/postcss/postcss-import/issues/242 for more background.

The main problem with this approach is error handling/reporting. Currently, it gives the user the error from the default parser. In the case of a malformed `.sss` import, this is quite unhelpful. Not sure what is the best route to improve this.

---

This is by no means a polished PR. I may end up totally rewriting the implementation. Anyway, it does provide a good test suite for how things should behave.

CC: @ai @MoOx 