### PR TITLE
BREAKING: File not found is an Error, not a Warning

### DIFF
--- a/index.js
+++ b/index.js
@@ -261,6 +261,7 @@ function resolveImportId(
     }, [])
   })
   .catch(function(err) {
+    if (err.message.indexOf("Failed to find") !== -1) throw err
     result.warn(err.message, { node: atRule })
   })
 }

--- a/test/import.js
+++ b/test/import.js
@@ -47,18 +47,14 @@ test("should not fail with absolute and local import", t => {
     })
 })
 
-test("should output readable trace", t => {
+test("should error when file not found", t => {
+  t.plan(1)
   var file = "fixtures/imports/import-missing.css"
   return postcss()
     .use(atImport())
     .process(readFileSync(file), { from: file })
-    .then(result => {
-      t.is(
-        result.warnings()[0].text,
-        /* eslint-disable max-len */
-        "Failed to find 'missing-file.css'\n    in [ \n        " + path.resolve("fixtures/imports") + "\n    ]"
-        /* eslint-enabme max-len */
-      )
+    .catch(err => {
+      t.truthy(err)
     })
 })
 


### PR DESCRIPTION
Fixes https://github.com/postcss/postcss-import/issues/192.

@MoOx What do you think of this? Is there some other case that we can test for a readable stack trace, since file not found is now an error?