### PR TITLE
Add `addModulesDirectories` config

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,19 @@ postcss: function(webpack) {
 }
 ```
 
+#### `addModulesDirectories`
+
+Type: `Array`  
+Default: `[]`
+
+An array of folder names to add to [Node's resolver](https://nodejs.org/api/modules.html#modules_loading_from_node_modules_folders).
+Values will be appended to the default resolve directories: 
+`["node_modules", "web_modules"]`.
+
+This option is only for adding additional directories to default resolver. If
+you provide your own resolver via the `resolve` configuration option above, then
+this value will be ignored.
+
 #### Example with some options
 
 ```js

--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ postcss: function(webpack) {
 Type: `Array`  
 Default: `[]`
 
-An array of folder names to add to [Node's resolver](https://nodejs.org/api/modules.html#modules_loading_from_node_modules_folders).
+An array of folder names to add to [Node's resolver](https://github.com/substack/node-resolve).
 Values will be appended to the default resolve directories: 
 `["node_modules", "web_modules"]`.
 

--- a/index.js
+++ b/index.js
@@ -16,6 +16,7 @@ function AtImport(options) {
     resolve: resolveId,
     load: loadContent,
     plugins: [],
+    addModulesDirectories: [],
   }, options)
 
   options.root = path.resolve(options.root)

--- a/lib/resolve-id.js
+++ b/lib/resolve-id.js
@@ -29,7 +29,7 @@ module.exports = function(id, base, options) {
 
   var resolveOpts = {
     basedir: base,
-    moduleDirectory: moduleDirectories,
+    moduleDirectory: moduleDirectories.concat(options.addModulesDirectories),
     paths: paths,
     extensions: [ ".css" ],
     packageFilter: function processPackage(pkg) {

--- a/test/fixtures/resolve-custom-modules.css
+++ b/test/fixtures/resolve-custom-modules.css
@@ -1,0 +1,7 @@
+@import "shared-fake";
+@import "shared-auto";
+@import "shared-nest";
+@import "shared-by-hand/style.css";
+@import "shared-use-dep";
+@import "shared-use-dep-too";
+@import "shared-use-dep" screen;

--- a/test/fixtures/resolve-custom-modules.expected.css
+++ b/test/fixtures/resolve-custom-modules.expected.css
@@ -1,0 +1,8 @@
+.shared-fake{}
+.shared-auto{}
+.shared-nested{}
+.shared-byHand{}
+.shared-dep{}
+@media screen{
+.shared-dep{}
+}

--- a/test/resolve.js
+++ b/test/resolve.js
@@ -54,3 +54,12 @@ test("should be able to consume npm package or local modules", t => {
     from: "fixtures/imports/foo.css",
   })
 })
+
+test("should be able to consume modules from custom modules directories", t => {
+  return compareFixtures(t, "resolve-custom-modules", {
+    path: null,
+    addModulesDirectories: [ "shared_modules" ],
+  }, {
+    from: "fixtures/imports/foo.css",
+  })
+})

--- a/test/shared_modules/shared-auto/index.css
+++ b/test/shared_modules/shared-auto/index.css
@@ -1,0 +1,1 @@
+.shared-auto{}

--- a/test/shared_modules/shared-by-hand/style.css
+++ b/test/shared_modules/shared-by-hand/style.css
@@ -1,0 +1,1 @@
+.shared-byHand{}

--- a/test/shared_modules/shared-dep/index.css
+++ b/test/shared_modules/shared-dep/index.css
@@ -1,0 +1,1 @@
+.shared-dep{}

--- a/test/shared_modules/shared-fake/main.css
+++ b/test/shared_modules/shared-fake/main.css
@@ -1,0 +1,1 @@
+.shared-fake{}

--- a/test/shared_modules/shared-fake/package.json
+++ b/test/shared_modules/shared-fake/package.json
@@ -1,0 +1,3 @@
+{
+  "style": "main.css"
+}

--- a/test/shared_modules/shared-nest/index.css
+++ b/test/shared_modules/shared-nest/index.css
@@ -1,0 +1,1 @@
+@import "shared-ed";

--- a/test/shared_modules/shared-nest/shared_modules/shared-ed/index.css
+++ b/test/shared_modules/shared-nest/shared_modules/shared-ed/index.css
@@ -1,0 +1,1 @@
+.shared-nested{}

--- a/test/shared_modules/shared-use-dep-too/index.css
+++ b/test/shared_modules/shared-use-dep-too/index.css
@@ -1,0 +1,1 @@
+@import "shared-dep";

--- a/test/shared_modules/shared-use-dep/index.css
+++ b/test/shared_modules/shared-use-dep/index.css
@@ -1,0 +1,1 @@
+@import "shared-dep";


### PR DESCRIPTION
Allows appending to the default list of modules directories. I picked a name that I think sounds good, but happy to change it if y'all have something else you'd prefer. 😄 

Relevant discussion: https://github.com/postcss/postcss-import/issues/195

@RyanZim 