### PR TITLE
Use PostCSS 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: node_js
 node_js:
-  - 'stable'
-  - '0.12'
+  - stable
+  - 4.5

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,8 +2,8 @@
 
 environment:
   matrix:
-    - nodejs_version: 5
-    - nodejs_version: 0.12
+    - nodejs_version: 7
+    - nodejs_version: 4.5
 
 version: "{build}"
 build: off

--- a/index.js
+++ b/index.js
@@ -1,6 +1,11 @@
+// builtin tooling
 var path = require("path")
+
+// external tooling
 var assign = require("object-assign")
 var postcss = require("postcss")
+
+// internal tooling
 var joinMedia = require("./lib/join-media")
 var resolveId = require("./lib/resolve-id")
 var loadContent = require("./lib/load-content")

--- a/lib/parse-statements.js
+++ b/lib/parse-statements.js
@@ -1,4 +1,7 @@
+// external tooling
 var valueParser = require("postcss-value-parser")
+
+// extended tooling
 var stringify = valueParser.stringify
 
 function split(params, start) {

--- a/lib/process-content.js
+++ b/lib/process-content.js
@@ -1,5 +1,10 @@
+// builtin tooling
 var path = require("path")
+
+// external tooling
 var postcss = require("postcss")
+
+// placeholder tooling
 var sugarss
 
 module.exports = function processContent(

--- a/lib/resolve-id.js
+++ b/lib/resolve-id.js
@@ -1,12 +1,5 @@
+// external tooling
 var resolve = require("resolve")
-var jspmResolve
-// Works around https://github.com/jspm/jspm-cli/pull/1779 is released
-try {
-  jspmResolve = require("pkg-resolve")
-}
-catch (ex) {
-  // pass
-}
 
 var moduleDirectories = [
   "web_modules",
@@ -46,12 +39,6 @@ module.exports = function(id, base, options) {
   return resolveModule("./" + id, resolveOpts)
   .catch(function() {
     return resolveModule(id, resolveOpts)
-  })
-  .catch(function() {
-    return jspmResolve.default(id, {
-      basedir: resolveOpts.basedir,
-      extensions : resolveOpts.extensions,
-    })
   })
   .catch(function() {
     if (paths.indexOf(base) === -1) {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "eslint-plugin-import": "^2.2.0",
     "npmpub": "^3.0.1",
     "postcss-scss": "^1.0.0",
-    "sugarss": "^0.2.0"
+    "sugarss": "^1.0.0"
   },
   "jspm": {
     "name": "postcss-import",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "resolve": "^1.1.7"
   },
   "devDependencies": {
-    "ava": "^0.16.0",
+    "ava": "^0.19.1",
     "eslint": "^3.19.0",
     "eslint-config-i-am-meticulous": "^6.0.1",
     "eslint-plugin-import": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -26,8 +26,9 @@
   },
   "devDependencies": {
     "ava": "^0.16.0",
-    "eslint": "^1.10.3",
-    "eslint-config-i-am-meticulous": "^2.0.0",
+    "eslint": "^3.19.0",
+    "eslint-config-i-am-meticulous": "^6.0.1",
+    "eslint-plugin-import": "^2.2.0",
     "npmpub": "^3.0.1",
     "postcss-scss": "^1.0.0",
     "sugarss": "^0.2.0"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   ],
   "dependencies": {
     "object-assign": "^4.0.1",
-    "postcss": "^5.0.14",
+    "postcss": "^6.0.1",
     "postcss-value-parser": "^3.2.3",
     "read-cache": "^1.0.0",
     "resolve": "^1.1.7"
@@ -29,7 +29,7 @@
     "eslint": "^1.10.3",
     "eslint-config-i-am-meticulous": "^2.0.0",
     "npmpub": "^3.0.1",
-    "postcss-scss": "^0.1.3",
+    "postcss-scss": "^1.0.0",
     "sugarss": "^0.2.0"
   },
   "jspm": {

--- a/test/custom-load.js
+++ b/test/custom-load.js
@@ -1,4 +1,7 @@
+// external tooling
 import test from "ava"
+
+// internal tooling
 import compareFixtures from "./helpers/compare-fixtures"
 
 test.serial("should accept content", t => {

--- a/test/custom-resolve.js
+++ b/test/custom-resolve.js
@@ -1,8 +1,15 @@
-import test from "ava"
-import compareFixtures from "./helpers/compare-fixtures"
-import postcss from "postcss"
-import atImport from ".."
+// builtin tooling
 import path from "path"
+
+// external tooling
+import test from "ava"
+import postcss from "postcss"
+
+// internal tooling
+import compareFixtures from "./helpers/compare-fixtures"
+
+// plugin
+import atImport from ".."
 
 test.serial("should accept file", t => {
   return compareFixtures(t, "custom-resolve-file", {

--- a/test/custom-resolve.js
+++ b/test/custom-resolve.js
@@ -14,7 +14,7 @@ import atImport from ".."
 test.serial("should accept file", t => {
   return compareFixtures(t, "custom-resolve-file", {
     resolve: () => {
-      return path.resolve("fixtures/imports/custom-resolve-1.css")
+      return path.resolve("test/fixtures/imports/custom-resolve-1.css")
     },
   })
 })
@@ -23,7 +23,7 @@ test.serial("should accept promised file", t => {
   return compareFixtures(t, "custom-resolve-file", {
     resolve: () => {
       return Promise.resolve(
-        path.resolve("fixtures/imports/custom-resolve-1.css")
+        path.resolve("test/fixtures/imports/custom-resolve-1.css")
       )
     },
   })
@@ -33,9 +33,9 @@ test.serial("should accept array of files", t => {
   return compareFixtures(t, "custom-resolve-array", {
     resolve: () => {
       return [
-        path.resolve("fixtures/imports/custom-resolve-1.css"),
-        path.resolve("fixtures/imports/custom-resolve-2.css"),
-        path.resolve("fixtures/imports/custom-resolve-1.css"),
+        path.resolve("test/fixtures/imports/custom-resolve-1.css"),
+        path.resolve("test/fixtures/imports/custom-resolve-2.css"),
+        path.resolve("test/fixtures/imports/custom-resolve-1.css"),
       ]
     },
   })
@@ -45,9 +45,9 @@ test.serial("should accept promised array of files", t => {
   return compareFixtures(t, "custom-resolve-array", {
     resolve: () => {
       return Promise.resolve([
-        path.resolve("fixtures/imports/custom-resolve-1.css"),
-        path.resolve("fixtures/imports/custom-resolve-2.css"),
-        path.resolve("fixtures/imports/custom-resolve-1.css"),
+        path.resolve("test/fixtures/imports/custom-resolve-1.css"),
+        path.resolve("test/fixtures/imports/custom-resolve-2.css"),
+        path.resolve("test/fixtures/imports/custom-resolve-1.css"),
       ])
     },
   })
@@ -62,11 +62,11 @@ test(
         return path.replace("foo", "imports/bar")
       },
       load: p => {
-        t.is(p, path.resolve("fixtures/imports", "bar.css"))
+        t.is(p, path.resolve("test/fixtures/imports", "bar.css"))
         return "/* comment */"
       },
     }))
-    .process(`@import "foo.css";`, { from: "fixtures/custom-resolve-file" })
+    .process(`@import "foo.css";`, { from: "test/fixtures/custom-resolve-file" })
     .then(result => {
       t.is(result.css, "/* comment */")
     })

--- a/test/custom-syntax-parser.js
+++ b/test/custom-syntax-parser.js
@@ -1,6 +1,9 @@
+// external tooling
 import test from "ava"
 import scss from "postcss-scss"
 import sugarss from "sugarss"
+
+// internal tooling
 import compareFixtures from "./helpers/compare-fixtures"
 import compareFixturesExt from "./helpers/compare-fixtures-ext"
 

--- a/test/fixtures/resolve-cwd.css
+++ b/test/fixtures/resolve-cwd.css
@@ -1,2 +1,2 @@
-@import "fixtures/imports/foo.css";
-@import "fixtures/imports/foo-recursive.css";
+@import "test/fixtures/imports/foo.css";
+@import "test/fixtures/imports/foo-recursive.css";

--- a/test/fixtures/resolve-local-modules.css
+++ b/test/fixtures/resolve-local-modules.css
@@ -1,6 +1,6 @@
-@import "fixtures/imports/modules/simple";
-@import "fixtures/imports/modules/empty";
-@import "fixtures/imports/modules/style";
-@import "fixtures/imports/modules/main";
-@import "fixtures/imports/modules/main-js";
-@import "fixtures/imports/modules/main-style";
+@import "test/fixtures/imports/modules/simple";
+@import "test/fixtures/imports/modules/empty";
+@import "test/fixtures/imports/modules/style";
+@import "test/fixtures/imports/modules/main";
+@import "test/fixtures/imports/modules/main-js";
+@import "test/fixtures/imports/modules/main-style";

--- a/test/helpers/compare-fixtures-ext.js
+++ b/test/helpers/compare-fixtures-ext.js
@@ -1,6 +1,11 @@
+// builtin tooling
 var fs = require("fs")
-var postcss = require("postcss")
+
+// external tooling
 var assign = require("object-assign")
+var postcss = require("postcss")
+
+// plugin
 var atImport = require("../..")
 
 function read(name, ext) {

--- a/test/helpers/compare-fixtures-ext.js
+++ b/test/helpers/compare-fixtures-ext.js
@@ -10,18 +10,18 @@ var atImport = require("../..")
 
 function read(name, ext) {
   if (!ext) ext = ".css"
-  return fs.readFileSync("fixtures/" + name + ext, "utf8")
+  return fs.readFileSync("test/fixtures/" + name + ext, "utf8")
 }
 
 module.exports = function(t, name, ext, opts, postcssOpts, warnings) {
-  opts = assign({ path: "fixtures/imports" }, opts)
+  opts = assign({ path: "test/fixtures/imports" }, opts)
   return postcss(atImport(opts))
     .process(read(name, ext), postcssOpts || {})
     .then(function(result) {
       var actual = result.css
       var expected = read(name + ".expected")
       // handy thing: checkout actual in the *.actual.css file
-      fs.writeFile("fixtures/" + name + ".actual.css", actual)
+      fs.writeFile("test/fixtures/" + name + ".actual.css", actual)
       t.is(actual, expected)
       if (!warnings) {
         warnings = []

--- a/test/helpers/compare-fixtures.js
+++ b/test/helpers/compare-fixtures.js
@@ -1,6 +1,11 @@
+// builtin tooling
 var fs = require("fs")
-var postcss = require("postcss")
+
+// external tooling
 var assign = require("object-assign")
+var postcss = require("postcss")
+
+// plugin
 var atImport = require("../..")
 
 function read(name) {

--- a/test/helpers/compare-fixtures.js
+++ b/test/helpers/compare-fixtures.js
@@ -9,18 +9,18 @@ var postcss = require("postcss")
 var atImport = require("../..")
 
 function read(name) {
-  return fs.readFileSync("fixtures/" + name + ".css", "utf8")
+  return fs.readFileSync("test/fixtures/" + name + ".css", "utf8")
 }
 
 module.exports = function(t, name, opts, postcssOpts, warnings) {
-  opts = assign({ path: "fixtures/imports" }, opts)
+  opts = assign({ path: "test/fixtures/imports" }, opts)
   return postcss(atImport(opts))
     .process(read(name), postcssOpts || {})
     .then(function(result) {
       var actual = result.css
       var expected = read(name + ".expected")
       // handy thing: checkout actual in the *.actual.css file
-      fs.writeFile("fixtures/" + name + ".actual.css", actual)
+      fs.writeFile("test/fixtures/" + name + ".actual.css", actual)
       t.is(actual, expected)
       if (!warnings) {
         warnings = []

--- a/test/import-events.js
+++ b/test/import-events.js
@@ -1,8 +1,13 @@
+// builtin tooling
+import { readFileSync } from "fs"
+import { resolve } from "path"
+
+// external tooling
 import test from "ava"
 import postcss from "postcss"
+
+// plugin
 import atImport from ".."
-import { resolve } from "path"
-import { readFileSync } from "fs"
 
 test("should have a callback that returns an object" +
   " containing imported files", t => {

--- a/test/import-events.js
+++ b/test/import-events.js
@@ -13,30 +13,30 @@ test("should have a callback that returns an object" +
   " containing imported files", t => {
   return postcss()
     .use(atImport({
-      path: "fixtures/imports",
+      path: "test/fixtures/imports",
       onImport: files => {
         t.deepEqual(
           files,
           [
-            resolve("fixtures/media-import.css"),
-            resolve("fixtures/imports/media-import-level-2.css"),
-            resolve("fixtures/imports/media-import-level-3.css"),
+            resolve("test/fixtures/media-import.css"),
+            resolve("test/fixtures/imports/media-import-level-2.css"),
+            resolve("test/fixtures/imports/media-import-level-3.css"),
           ]
         )
       },
     }))
-    .process(readFileSync("fixtures/media-import.css"), {
-      from: "fixtures/media-import.css",
+    .process(readFileSync("test/fixtures/media-import.css"), {
+      from: "test/fixtures/media-import.css",
     })
 })
 
 test("should add dependency message for each import", t => {
   return postcss()
     .use(atImport({
-      path: "fixtures/imports",
+      path: "test/fixtures/imports",
     }))
-    .process(readFileSync("fixtures/media-import.css"), {
-      from: "fixtures/media-import.css",
+    .process(readFileSync("test/fixtures/media-import.css"), {
+      from: "test/fixtures/media-import.css",
     })
     .then((result) => {
       var deps = result.messages.filter(
@@ -45,13 +45,13 @@ test("should add dependency message for each import", t => {
       var expected = [
         {
           type: "dependency",
-          file: resolve("fixtures/imports/media-import-level-2.css"),
-          parent: resolve("fixtures/media-import.css"),
+          file: resolve("test/fixtures/imports/media-import-level-2.css"),
+          parent: resolve("test/fixtures/media-import.css"),
         },
         {
           type: "dependency",
-          file: resolve("fixtures/imports/media-import-level-3.css"),
-          parent: resolve("fixtures/imports/media-import-level-2.css"),
+          file: resolve("test/fixtures/imports/media-import-level-3.css"),
+          parent: resolve("test/fixtures/imports/media-import-level-2.css"),
         },
       ]
       t.deepEqual(deps, expected)

--- a/test/import.js
+++ b/test/import.js
@@ -1,9 +1,16 @@
-import test from "ava"
-import path from "path"
+// builtin tooling
 import { readFileSync } from "fs"
+import path from "path"
+
+// external tooling
+import test from "ava"
 import postcss from "postcss"
-import atImport from ".."
+
+// internal tooling
 import compareFixtures from "./helpers/compare-fixtures"
+
+// plugin
+import atImport from ".."
 
 test("should import stylsheets", t => {
   return compareFixtures(t, "simple")

--- a/test/import.js
+++ b/test/import.js
@@ -48,7 +48,7 @@ test("should not fail with only one absolute import", t => {
 test("should not fail with absolute and local import", t => {
   return postcss()
     .use(atImport())
-    .process("@import url('http://');\n@import 'fixtures/imports/foo.css';")
+    .process("@import url('http://');\n@import 'test/fixtures/imports/foo.css';")
     .then(result => {
       t.is(result.css, "@import url('http://');\nfoo{}")
     })
@@ -56,7 +56,7 @@ test("should not fail with absolute and local import", t => {
 
 test("should error when file not found", t => {
   t.plan(1)
-  var file = "fixtures/imports/import-missing.css"
+  var file = "test/fixtures/imports/import-missing.css"
   return postcss()
     .use(atImport())
     .process(readFileSync(file), { from: file })
@@ -68,8 +68,8 @@ test("should error when file not found", t => {
 test("should contain a correct sourcemap", t => {
   return postcss()
     .use(atImport())
-    .process(readFileSync("sourcemap/in.css"), {
-      from: "sourcemap/in.css",
+    .process(readFileSync("test/sourcemap/in.css"), {
+      from: "test/sourcemap/in.css",
       to: null,
       map: {
         inline: false,
@@ -78,7 +78,7 @@ test("should contain a correct sourcemap", t => {
     .then(result => {
       t.is(
         result.map.toString(),
-        readFileSync("sourcemap/out.css.map", "utf8").trim()
+        readFileSync("test/sourcemap/out.css.map", "utf8").trim()
       )
     })
 })
@@ -86,7 +86,7 @@ test("should contain a correct sourcemap", t => {
 test("inlined @import should keep PostCSS AST references clean", t => {
   return postcss()
     .use(atImport())
-    .process("@import 'fixtures/imports/foo.css';\nbar{}")
+    .process("@import 'test/fixtures/imports/foo.css';\nbar{}")
     .then(result => {
       result.root.nodes.forEach(node => {
         t.is(result.root, node.parent)
@@ -96,9 +96,9 @@ test("inlined @import should keep PostCSS AST references clean", t => {
 
 test("should work with empty files", t => {
   return compareFixtures(t, "empty-and-useless", {
-    path: "fixtures/imports",
+    path: "test/fixtures/imports",
   }, null, [
-    path.resolve("fixtures/imports/empty.css") + " is empty",
+    path.resolve("test/fixtures/imports/empty.css") + " is empty",
   ])
 })
 

--- a/test/lint.js
+++ b/test/lint.js
@@ -1,5 +1,8 @@
+// external tooling
 import test from "ava"
 import postcss from "postcss"
+
+// plugin
 import atImport from ".."
 
 const processor = postcss().use(atImport())

--- a/test/lint.js
+++ b/test/lint.js
@@ -60,10 +60,10 @@ test("should warn if something before comments", t => {
 test("should not warn when @charset or @import statement before", t => {
   return Promise.all([
     processor.process(`@import "bar.css"; @import "bar.css";`, {
-      from: "fixtures/imports/foo.css",
+      from: "test/fixtures/imports/foo.css",
     }),
     processor.process(`@charset "bar.css"; @import "bar.css";`, {
-      from: "fixtures/imports/foo.css",
+      from: "test/fixtures/imports/foo.css",
     }),
   ])
   .then(function(results) {

--- a/test/media.js
+++ b/test/media.js
@@ -1,4 +1,7 @@
+// external tooling
 import test from "ava"
+
+// internal tooling
 import compareFixtures from "./helpers/compare-fixtures"
 
 test("should resolve media queries of import statements", t => {

--- a/test/order.js
+++ b/test/order.js
@@ -9,10 +9,10 @@ test(`should order nested imports correctly`, t => {
   var path = require("path")
 
   return compareFixtures(t, "order", {
-    path: "fixtures/imports",
+    path: "test/fixtures/imports",
     resolve: (id) => {
       return new Promise(function(res) {
-        var doResolve = () => res(path.resolve("fixtures/imports", id))
+        var doResolve = () => res(path.resolve("test/fixtures/imports", id))
 
         if (first) {
           // Delay the first import so the second gets loaded first

--- a/test/order.js
+++ b/test/order.js
@@ -1,4 +1,7 @@
+// external tooling
 import test from "ava"
+
+// internal tooling
 import compareFixtures from "./helpers/compare-fixtures"
 
 test(`should order nested imports correctly`, t => {

--- a/test/plugins.js
+++ b/test/plugins.js
@@ -1,7 +1,12 @@
+// external tooling
 import test from "ava"
 import postcss from "postcss"
-import atImport from ".."
+
+// internal tooling
 import compareFixtures from "./helpers/compare-fixtures"
+
+// plugin
+import atImport from ".."
 
 test("should apply plugins to root", t => {
   const atRules = []

--- a/test/plugins.js
+++ b/test/plugins.js
@@ -48,10 +48,13 @@ test("should error when value is not an array", t => {
     })
 })
 
-test("should remain silent when value is an empty array", () => {
+test("should remain silent when value is an empty array", t => {
   return postcss()
     .use(atImport({
       plugins: [],
     }))
     .process("")
+    .then((result) => {
+      t.is(result.css, "")
+    })
 })

--- a/test/resolve.js
+++ b/test/resolve.js
@@ -1,4 +1,7 @@
+// external tooling
 import test from "ava"
+
+// internal tooling
 import compareFixtures from "./helpers/compare-fixtures"
 
 test("should resolve relative to cwd", t => {

--- a/test/resolve.js
+++ b/test/resolve.js
@@ -12,7 +12,7 @@ test("should resolve relative to cwd", t => {
 
 test(`should resolve relative to 'root' option`, t => {
   return compareFixtures(t, "resolve-root", {
-    root: "fixtures",
+    root: "test/fixtures",
     path: null,
   })
 })
@@ -21,19 +21,19 @@ test(`should resolve relative to postcss 'from' option`, t => {
   return compareFixtures(t, "resolve-from", {
     path: null,
   }, {
-    from: "fixtures/file.css",
+    from: "test/fixtures/file.css",
   })
 })
 
 test(`should resolve relative to 'path' which resolved with cwd`, t => {
   return compareFixtures(t, "resolve-path-cwd", {
-    path: "fixtures/imports",
+    path: "test/fixtures/imports",
   })
 })
 
 test(`should resolve relative to 'path' which resolved with 'root'`, t => {
   return compareFixtures(t, "resolve-path-root", {
-    root: "fixtures",
+    root: "test/fixtures",
     path: "imports",
   })
 })
@@ -46,7 +46,7 @@ test("should resolve local modules", t => {
 
 test("should resolve local modules", t => {
   return compareFixtures(t, "resolve-path-modules", {
-    path: "fixtures/imports/modules",
+    path: "test/fixtures/imports/modules",
   })
 })
 
@@ -54,7 +54,7 @@ test("should be able to consume npm package or local modules", t => {
   return compareFixtures(t, "resolve-modules", {
     path: null,
   }, {
-    from: "fixtures/imports/foo.css",
+    from: "test/fixtures/imports/foo.css",
   })
 })
 
@@ -63,6 +63,6 @@ test("should be able to consume modules from custom modules directories", t => {
     path: null,
     addModulesDirectories: [ "shared_modules" ],
   }, {
-    from: "fixtures/imports/foo.css",
+    from: "test/fixtures/imports/foo.css",
   })
 })

--- a/test/sourcemap/out.css.map
+++ b/test/sourcemap/out.css.map
@@ -1,1 +1,1 @@
-{"version":3,"sources":["sourcemap/imported.css","sourcemap/in.css"],"names":[],"mappings":"AAAA;EACE,iBAAiB;CAClB;;ACAD;EACE,WAAW;CACZ","file":"sourcemap/in.css","sourcesContent":["html {\n  background: blue;\n}","@import \"imported.css\";\n\nbody {\n  color: red;\n}\n"]}
+{"version":3,"sources":["test/sourcemap/imported.css","test/sourcemap/in.css"],"names":[],"mappings":"AAAA;EACE,iBAAiB;CAClB;;ACAD;EACE,WAAW;CACZ","file":"test/sourcemap/in.css","sourcesContent":["html {\n  background: blue;\n}","@import \"imported.css\";\n\nbody {\n  color: red;\n}\n"]}


### PR DESCRIPTION
This PR updates PostCSS 6 and all dependencies. It is divided into separate commits, all of which individually pass testing.

- Updates PostCSS 6, which requires changes to .travis.yml and appveyor.yml
- Updates eslint, which requires changes to most test scripts to meet eslint-config-i-am-meticulous requirements
- Updates sugarss, no troubles
- Updates AVA, which requires updates to most tests as the current directory is now the package directory (see avajs/ava#1074)

_Note: eslint did require removing the jspmResolve oddity._