### PR TITLE
Fix linting options

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,11 +31,11 @@
     "npmpub": "^3.0.1",
     "postcss-scss": "^1.0.0",
     "prettier": "^1.3.1",
-    "prettier-eslint-cli": "^3.4.3",
+    "prettier-eslint-cli": "^4.0.0",
     "sugarss": "^1.0.0"
   },
   "scripts": {
-    "lint": "prettier-eslint \"**/*.js\" --write --prettier.semi false --prettier.trailing-comma es5",
+    "lint": "prettier-eslint \"**/*.js\" --write --semi false --trailing-comma es5",
     "pretest": "npm run lint",
     "test": "ava",
     "release": "npmpub"


### PR DESCRIPTION
because `prettier-eslint-cli` mistakenly published breaking change as a minor patch in v3 ([issue](https://github.com/prettier/prettier-eslint-cli/issues/67)) the ci tests fail. I changed `prettier-eslint-cli` to the latest version and fixed options in lint script to reflect the changes introduced in the new version.