### PR TITLE
Remove transform option from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,6 @@ var atImport = require("postcss-import")
 postcss()
   .use(atImport({
     path: ["src/css"],
-    transform: require("css-whitespace")
   }))
   .process(cssString)
   .then(function (result) {


### PR DESCRIPTION
As far as I know, transform option is removed, isn't it? Or can I still use it only in this case?