### PR TITLE
Adding filter method

### DIFF
--- a/index.js
+++ b/index.js
@@ -140,6 +140,17 @@ function parseStyles(result, styles, options, state, media) {
             return
           }
 
+          if (options.filter) {
+            let filtered = options.filter(stmt.uri);
+
+            if (filtered === false) {
+              return;
+            }
+            if (typeof filtered === "string"){
+              stmt.uri = filtered;
+            }
+          }
+
           return resolveImportId(result, stmt, options, state)
         })
       }, Promise.resolve())

--- a/index.js
+++ b/index.js
@@ -146,9 +146,6 @@ function parseStyles(result, styles, options, state, media) {
             if (filtered === false) {
               return;
             }
-            if (typeof filtered === "string"){
-              stmt.uri = filtered;
-            }
           }
 
           return resolveImportId(result, stmt, options, state)


### PR DESCRIPTION
This is a continuation of https://github.com/postcss/postcss-import/pull/259 since it seems to be abandoned. I have updated the name to `filter`.

If the logic/implementation looks good, I will go ahead and add documentation.


Example postcss config file:
```
module.exports = {
	plugins: [
		require('postcss-import')({
			filter(url) {
				if (url.match(/font\.css$/)) {
					return false;
				}
			},
		}),
	],
};
```