### PR TITLE
Fixed: do not preserve symlinks as per Node's default behaviour

### DIFF
--- a/lib/resolve-id.js
+++ b/lib/resolve-id.js
@@ -24,6 +24,7 @@ module.exports = function(id, base, options) {
       else if (!pkg.main || !/\.css$/.test(pkg.main)) pkg.main = "index.css"
       return pkg
     },
+    preserveSymlinks: false,
   }
 
   return resolveModule(`./${id}`, resolveOpts)


### PR DESCRIPTION
There's a bug in the current version of PostCSS import plugin that occurs when using symlinks and causes invalid dependencies to be loaded in when using different versions of the same dependency within the same app. 

The bug occurs as the default behaviour of the `resolve` module (used to resolve ids to filenames) is different to the default behaviour of Node.js's native `require.resolve` method. 

I know this is probably a bit of an edge case as most people don't use symlinks but it causes huge issues in monorepos (e.g. lerna / yarn workspaces).

The fix is to disable the following option in the `resolve` module:
* `opts.preserveSymlinks` - if true, doesn't resolve basedir to real path before resolving. This is the way Node resolves dependencies when executed with the `--preserve-symlinks` flag. Note: this property is currently true by default but it will be changed to false in the next major version because Node's resolution algorithm does not preserve symlinks by default.
(https://www.npmjs.com/package/resolve)