### PR TITLE
Adding filename to resolver arguments

### DIFF
--- a/index.js
+++ b/index.js
@@ -184,7 +184,7 @@ function resolveImportId(result, stmt, options, state) {
       // Ensure that each path is absolute:
       return Promise.all(
         paths.map(file => {
-          return !path.isAbsolute(file) ? resolveId(file, base, options) : file
+          return !path.isAbsolute(file) ? resolveId(file, base, options, path.basename(atRule.source.input.file)) : file
         })
       )
     })

--- a/index.js
+++ b/index.js
@@ -178,13 +178,13 @@ function resolveImportId(result, stmt, options, state) {
     ? path.dirname(atRule.source.input.file)
     : options.root
 
-  return Promise.resolve(options.resolve(stmt.uri, base, options))
+  return Promise.resolve(options.resolve(stmt.uri, base, options, path.basename(atRule.source.input.file)))
     .then(paths => {
       if (!Array.isArray(paths)) paths = [paths]
       // Ensure that each path is absolute:
       return Promise.all(
         paths.map(file => {
-          return !path.isAbsolute(file) ? resolveId(file, base, options, path.basename(atRule.source.input.file)) : file
+          return !path.isAbsolute(file) ? resolveId(file, base, options) : file
         })
       )
     })


### PR DESCRIPTION
It would be nice to be able to know from which file the import is made in the custom resolver. Currently it only sends the directory name of this file.
I would suggest sending the filename as another argument.