### PR TITLE
Change from filename to checksum duplicates

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 "use strict"
 // builtin tooling
 const path = require("path")
+const md5File = require("md5-file")
 
 // external tooling
 const postcss = require("postcss")
@@ -215,15 +216,17 @@ function resolveImportId(result, stmt, options, state) {
 function loadImportContent(result, stmt, filename, options, state) {
   const atRule = stmt.node
   const media = stmt.media
+  const fileHash = md5File.sync(filename)
+
   if (options.skipDuplicates) {
     // skip files already imported at the same scope
-    if (state.importedFiles[filename] && state.importedFiles[filename][media]) {
+    if ((state.importedFiles[fileHash] && state.importedFiles[fileHash][media])) {
       return
     }
 
     // save imported files to skip them next time
-    if (!state.importedFiles[filename]) state.importedFiles[filename] = {}
-    state.importedFiles[filename][media] = true
+    if (!state.importedFiles[fileHash]) state.importedFiles[fileHash] = {}
+    state.importedFiles[fileHash][media] = true
   }
 
   return Promise.resolve(options.load(filename, options)).then(content => {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "lib"
   ],
   "dependencies": {
+    "md5-file": "^3.2.3",
     "postcss": "^6.0.1",
     "postcss-value-parser": "^3.2.3",
     "read-cache": "^1.0.0",


### PR DESCRIPTION
When saving files to the list of includedFiles it currently uses the
full file path which doesn't work well in monorepos. I've changed to
store an MD5 hash of the file so that different version files can be
used, but they can live in different directories.

An example of where this is causing problems:

We have a monorepo that has a shared 'core' for the CSS. We import this in to every package but as its a dependency the file path can often be <package-name>/node_modules/core/src/index.css - currently with the file path check it sees every one as a different file.