### PR TITLE
Added RxJS Style NPM packages and tests

### DIFF
--- a/test/fixtures/resolve-npm-subpackages.css
+++ b/test/fixtures/resolve-npm-subpackages.css
@@ -1,0 +1,2 @@
+@import "modularized-css/foo";
+@import "modularized-css/foo/boo/boomod.css";

--- a/test/fixtures/resolve-npm-subpackages.expected.css
+++ b/test/fixtures/resolve-npm-subpackages.expected.css
@@ -1,0 +1,2 @@
+.i-pity-the-foo{}
+.i-pity-the-boo{}

--- a/test/node_modules/modularized-css/foo/boo/boomod.css
+++ b/test/node_modules/modularized-css/foo/boo/boomod.css
@@ -1,0 +1,1 @@
+.i-pity-the-boo{}

--- a/test/node_modules/modularized-css/foo/index.css
+++ b/test/node_modules/modularized-css/foo/index.css
@@ -1,0 +1,1 @@
+.i-pity-the-foo{}

--- a/test/resolve.js
+++ b/test/resolve.js
@@ -52,6 +52,14 @@ test(
 )
 
 test(
+  "should be able to consume npm sub packages",
+  checkFixture,
+  "resolve-npm-subpackages",
+  { path: null },
+  { from: "test/fixtures/imports/foo.css" }
+)
+
+test(
   "should be able to consume modules from custom modules directories",
   checkFixture,
   "resolve-custom-modules",


### PR DESCRIPTION
Added tests that show the ability of postcss-import to consume RxJS style subpackages.  In other words instead of consuming the entire kitchen sink via the `style` or `main` attribute, only consume a subpackage of the npm module.