### PR TITLE
Set plugin property to dependency messages which is required according to the API doc

### DIFF
--- a/index.js
+++ b/index.js
@@ -199,6 +199,7 @@ function resolveImportId(result, stmt, options, state) {
       resolved.forEach(file => {
         result.messages.push({
           type: "dependency",
+          plugin: "postcss-import",
           file: file,
           parent: sourceFile,
         })

--- a/test/import-events.js
+++ b/test/import-events.js
@@ -22,11 +22,13 @@ test("should add dependency message for each import", t => {
       const expected = [
         {
           type: "dependency",
+          plugin: "postcss-import",
           file: resolve("test/fixtures/imports/media-import-level-2.css"),
           parent: resolve("test/fixtures/media-import.css"),
         },
         {
           type: "dependency",
+          plugin: "postcss-import",
           file: resolve("test/fixtures/imports/media-import-level-3.css"),
           parent: resolve("test/fixtures/imports/media-import-level-2.css"),
         },


### PR DESCRIPTION
This PR fixes #379. The lack of `plugin` property leads to a message mishandling by other plugins and may cause an issue described as the second problem in https://github.com/nodaguti/postcss-calc-warning.