### PR TITLE
caseSensitive option to trigger failures due to case-sensitive file system paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,16 @@ This option is only for adding additional directories to default resolver. If
 you provide your own resolver via the `resolve` configuration option above, then
 this value will be ignored.
 
+#### `caseSensitive`
+
+Type: `Boolean`  
+Default: `false`
+
+By default, importing will rely on the file system that the build is being run on. For
+example, NTFS commonly used with Windows is a case-sensitive file system while HFS+ used 
+by MacOS is case-insensitive. When enabled, it will check for case-sensitive issues in 
+file paths.
+
 #### Example with some options
 
 ```js

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 "use strict"
 // builtin tooling
 const path = require("path")
+const fs = require("fs")
 
 // external tooling
 const postcss = require("postcss")
@@ -18,6 +19,7 @@ function AtImport(options) {
       root: process.cwd(),
       path: [],
       skipDuplicates: true,
+      caseSensitive: false,
       resolve: resolveId,
       load: loadContent,
       plugins: [],
@@ -190,6 +192,21 @@ function resolveImportId(result, stmt, options, state) {
       // Ensure that each path is absolute:
       return Promise.all(
         paths.map(file => {
+          if (options.caseSensitive) {
+            // check path for case senstive inconsistencies
+            const dir = path.dirname(file)
+            const filenames = fs.readdirSync(dir)
+
+            if (
+              !dir === path.dirname(dir) ||
+              filenames.indexOf(path.basename(file)) === -1
+            ) {
+              throw new Error(
+                `Case sensitive file path issue found with file ${file}`
+              )
+            }
+          }
+
           return !path.isAbsolute(file) ? resolveId(file, base, options) : file
         })
       )

--- a/test/import.js
+++ b/test/import.js
@@ -54,6 +54,13 @@ test("should error when file not found", t => {
     .catch(err => t.truthy(err))
 })
 
+test("should error when there are filepath case-inconsistencies found", t => {
+  return postcss()
+    .use(atImport({ caseSensitive: true }))
+    .process("@import 'test/fixtures/imports/Foo.css';", { from: undefined })
+    .catch(err => t.truthy(err))
+})
+
 test("should contain a correct sourcemap", t => {
   return postcss()
     .use(atImport())


### PR DESCRIPTION
While using postcss-import, I found that imports and builds were failing once we uploaded them to the server, but not locally. This was because I was using a noncase-sensitive file system (HFS+) while the server was using a case-sensitive file system (NTFS). This option should allow local builds to fail due to case-sensitive paths regardless if the dev's file system is case-sensitive or not.