### PR TITLE
Added github action to convert to Deno

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -3,6 +3,7 @@ name: Deno
 on:
   push:
     tags:
+      - "*"
 
 jobs:
   build:

--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -3,7 +3,6 @@ name: Deno
 on:
   push:
     tags:
-      - "*"
 
 jobs:
   build:
@@ -11,7 +10,7 @@ jobs:
 
     steps:
       - name: Setup Deno environment
-        uses: denolib/setup-deno@v2.2.0
+        uses: denolib/setup-deno@v2.3.0
         with:
           deno-version: v1.x
 
@@ -32,9 +31,6 @@ jobs:
           rm -rf deno
           deno run --unstable --allow-write --allow-read to_deno.js
           deno fmt deno
-          cp postcss/README.md deno/
-          cp postcss/CHANGELOG.md deno/
-          cp postcss/LICENSE deno/
 
           deno test --unstable --allow-read deno/test/*
 

--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -1,0 +1,53 @@
+name: Deno
+
+on:
+  push:
+    tags:
+      - "13.*"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Setup Deno environment
+        uses: denolib/setup-deno@v2.2.0
+        with:
+          deno-version: v1.x
+
+      - name: Checkout postcss-deno-import
+        uses: actions/checkout@v2
+        with:
+          repository: postcss/postcss-deno-import
+          token: ${{ secrets.PAT }}
+
+      - name: Checkout sources
+        uses: actions/checkout@v2
+        with:
+          ref: master
+          path: postcss-import
+
+      - name: Convert the code
+        run: |
+          rm -rf deno
+          deno run --unstable --allow-write --allow-read to_deno.js
+          deno fmt deno
+          cp postcss/README.md deno/
+          cp postcss/CHANGELOG.md deno/
+          cp postcss/LICENSE deno/
+
+          deno test --unstable --allow-read deno/test/*
+
+      - name: Get the tag name
+        id: get_version
+        run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
+
+      - name: Commit the changes and create the tag
+        run: |
+          git config user.name deno-conversion
+          git config user.email github-actions@github.com
+          git add deno
+          git commit -m "update code"
+          git push
+          git tag ${{ steps.get_version.outputs.VERSION }}
+          git push --tags

--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -3,7 +3,7 @@ name: Deno
 on:
   push:
     tags:
-      - "13.*"
+      - "*"
 
 jobs:
   build:

--- a/README.md
+++ b/README.md
@@ -219,6 +219,19 @@ postcss()
 
 This is mainly for use by postcss runners that implement file watching.
 
+## Usage in Deno
+
+This plugin is available for [Deno](https://deno.land/):
+
+```js
+import postcss from "https://deno.land/x/postcss/mod.js";
+import postcssImport from "https://deno.land/x/postcss-import/mod.js";
+
+const result = await postcss([postcssImport]).process(css);
+```
+
+Note that the Deno version has not support for module resolution like Node (packages installed with npm or folders with a `package.json` file).
+
 ---
 
 ## CONTRIBUTING

--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ import postcssImport from "https://deno.land/x/postcss_import/mod.js";
 const result = await postcss([postcssImport]).process(css);
 ```
 
-Note that the Deno version has not support for module resolution like Node (packages installed with npm or folders with a `package.json` file).
+Note that the Deno version does not support Node-like module resolution (packages installed with npm or folders with a `package.json` file).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ This plugin is available for [Deno](https://deno.land/):
 
 ```js
 import postcss from "https://deno.land/x/postcss/mod.js";
-import postcssImport from "https://deno.land/x/postcss-import/mod.js";
+import postcssImport from "https://deno.land/x/postcss_import/mod.js";
 
 const result = await postcss([postcssImport]).process(css);
 ```


### PR DESCRIPTION
This PR adds a github action that is runned after creating new tags, so it will update automatically the code in the https://github.com/postcss/postcss-deno-import repository (the Deno version of the plugin) and create the same tag there.

The only requirement is a secret variable with a [PAT](https://docs.github.com/en/free-pro-team@latest/github/authenticating-to-github/creating-a-personal-access-token) that have writting access to postcss-deno-import repository in order to commit the changes and create the new tag. So, after merging this PR, you have to:

- Go to Settings > Secrets of this repository
- Click in "New Secret"
- The secret name is `PAT`, and the value the access token

That's all.