### PR TITLE
Fix conflict with tailwindcss when using @tailwind before @import

### DIFF
--- a/lib/parse-statements.js
+++ b/lib/parse-statements.js
@@ -85,7 +85,7 @@ function parseImport(result, atRule) {
       if (
         prev.type !== "comment" &&
         (prev.type !== "atrule" ||
-          (prev.name !== "import" && prev.name !== "charset"))
+          (prev.name !== "import" && prev.name !== "charset" && prev.name !== "tailwind"))
       ) {
         return result.warn(
           "@import must precede all other statements (besides @charset)",


### PR DESCRIPTION
Hello there
This PR will fix the conflict between postcss-import and tailwindcss when we try to use import after tailwind's @tailwind base or @tailwind components
well obviously we can put @import before these two statements but in the result our custom CSS will be added "before" normalize styles and that is not pretty or standard.

After this PR the above syntax is valid

<pre>
@tailwind base;
@tailwind components;

@import "./buttons.css";
</pre>

Sorry for my bad English.