### PR TITLE
[DRAFT] Allows intercepting and skipping the AtRule node

### DIFF
--- a/index.js
+++ b/index.js
@@ -120,7 +120,7 @@ function AtImport(options) {
       }
 
       function parseStyles(result, styles, options, state, media) {
-        const statements = parseStatements(result, styles)
+        const statements = parseStatements(result, styles, options)
 
         return Promise.resolve(statements)
           .then(stmts => {

--- a/lib/parse-statements.js
+++ b/lib/parse-statements.js
@@ -20,14 +20,14 @@ function split(params, start) {
   return list
 }
 
-module.exports = function (result, styles) {
+module.exports = function (result, styles, options) {
   const statements = []
   let nodes = []
 
   styles.each(node => {
     let stmt
     if (node.type === "atrule") {
-      if (node.name === "import") stmt = parseImport(result, node)
+      if (node.name === "import") stmt = parseImport(result, node, options)
       else if (node.name === "media") stmt = parseMedia(result, node)
       else if (node.name === "charset") stmt = parseCharset(result, node)
     }
@@ -78,7 +78,16 @@ function parseCharset(result, atRule) {
   }
 }
 
-function parseImport(result, atRule) {
+function parseImport(result, atRule, options) {
+  if (options.interceptAtRule) {
+    options.interceptAtRule(atRule);
+  }
+  if (atRule.skip) {
+    return result.warn(
+      "@import was skipped by interceptAtRule",
+      { node: atRule }
+    )
+  }
   let prev = atRule.prev()
   if (prev) {
     do {


### PR DESCRIPTION
While postcss-import crawls imports, it is often handy to be able to
mutate the rule before processing. Unfortunately I was unable to
accomplish this by using a plugin before postcss-import. This is due to
rules not being revisited after concatenated with postcss-import.

I also found it odd that there was no way to signal a skip for a given
rule. By signaling a `skip = true` on the node, postcss-imports safely
skips over, but emits a warning. I don't like mutating the AtRule
object with a custom skip property, but this works for now.

Let me know if you need specific background on the motivation for
this change. Opening as draft, since there are no unit tests or
documentation for this change yet. I want to vet this with the team
first to make sure the change is acceptable. 