### PR TITLE
layers support

### DIFF
--- a/lib/parse-statements.js
+++ b/lib/parse-statements.js
@@ -134,11 +134,27 @@ function parseImport(result, atRule) {
   else stmt.uri = params[0].nodes[0].value
   stmt.fullUri = stringify(params[0])
 
-  if (params.length > 2) {
-    if (params[1].type !== "space") {
+  let remainder = params
+  if (remainder.length > 2) {
+    if (
+      (remainder[2].type === "word" || remainder[2].type === "function") &&
+      remainder[2].value === "layer"
+    ) {
+      if (remainder[1].type !== "space") {
+        return result.warn("Invalid import layer statement", { node: atRule })
+      }
+
+      stmt.layer = stringify(remainder[2])
+      remainder = remainder.slice(2)
+    }
+  }
+
+  if (remainder.length > 2) {
+    if (remainder[1].type !== "space") {
       return result.warn("Invalid import media statement", { node: atRule })
     }
-    stmt.media = split(params, 2)
+
+    stmt.media = split(remainder, 2)
   }
 
   return stmt

--- a/test/fixtures/layer.css
+++ b/test/fixtures/layer.css
@@ -1,0 +1,6 @@
+@import "foo.css" layer;
+@import 'bar.css' layer(bar);
+@import url(baz.css) layer;
+@import url("foobar.css") layer(foobar);
+
+content{}

--- a/test/fixtures/layer.expected.css
+++ b/test/fixtures/layer.expected.css
@@ -1,0 +1,14 @@
+@layer {
+  foo {}
+}
+@layer bar {
+  bar {}
+}
+@layer {
+  baz {}
+}
+@layer foobar {
+  foobar {}
+}
+
+content{}

--- a/test/layer.js
+++ b/test/layer.js
@@ -1,0 +1,8 @@
+"use strict"
+// external tooling
+const test = require("ava")
+
+// internal tooling
+const checkFixture = require("./helpers/check-fixture")
+
+test("should resolve layers of import statements", checkFixture, "layer")


### PR DESCRIPTION
_wip_

With `@layer` support soon in all browsers stylesheet authors will also start using these in `@import`.

spec : https://drafts.csswg.org/css-cascade-5/#at-import

new syntax :

```
@import [ <url> | <string> ]
        [ layer |  layer(<layer-name>) ]?
        <import-condition> ;
```

Because I am not familiar with the codebase I first wanted to checkin to make sure I am on the right track.

Status :

- [x] detects and parses `layer`
- [x] failing simple test
- [ ] transform
- [ ] increase test coverage

The intention is to have this transform :

```pcss
@import "foo.css" layer;

/* becomes */

@layer {
  foo {}
}
``` 

I could not easily find the best place to intervene and create a new `atRule` for the layers. Is this something you can help out with @ai?