### PR TITLE
fix import with layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ Type: `Function`
 Default: `null`
 
 You can provide a custom naming function for anonymous layers (`@import 'baz.css' layer;`).
-This function gets `(index, filename, importRule)` arguments and should return a unique string.
+This function gets `(index, filename)` arguments and should return a unique string.
 
 This option only influences imports without a layer name.
 Without this option the plugin will warn on anonymous layers.

--- a/README.md
+++ b/README.md
@@ -190,6 +190,20 @@ This option is only for adding additional directories to default resolver. If
 you provide your own resolver via the `resolve` configuration option above, then
 this value will be ignored.
 
+#### `nameLayer`
+
+Type: `Function`
+Default: `null`
+
+You can provide a custom naming function for anonymous layers (`@import 'baz.css' layer;`).
+This function gets `(index, filename, importRule)` arguments and should return a unique string.
+
+This option only influences imports without a layer name.
+Without this option the plugin will warn on anonymous layers.
+
+Anonymous layers are very difficult to mimic for this plugin
+but they are equivalent to uniquely named layers.
+
 #### Example with some options
 
 ```js

--- a/README.md
+++ b/README.md
@@ -196,13 +196,10 @@ Type: `Function`
 Default: `null`
 
 You can provide a custom naming function for anonymous layers (`@import 'baz.css' layer;`).
-This function gets `(index, filename)` arguments and should return a unique string.
+This function gets `(index, rootFilename)` arguments and should return a unique string.
 
 This option only influences imports without a layer name.
 Without this option the plugin will warn on anonymous layers.
-
-Anonymous layers are very difficult to mimic for this plugin
-but they are equivalent to uniquely named layers.
 
 #### Example with some options
 

--- a/index.js
+++ b/index.js
@@ -308,9 +308,11 @@ function AtImport(options) {
       function loadImportContent(result, stmt, filename, options, state) {
         const atRule = stmt.node
         const { media, layer } = stmt
-        if (layer.length === 1 && layer[0] === "") {
-          layer[0] = `importted-anon-layer-${state.anonymousLayerCounter++}`
-        }
+        layer.forEach((layerPart, i) => {
+          if (layerPart === "") {
+            layer[i] = `imported-anon-layer-${state.anonymousLayerCounter++}`
+          }
+        })
 
         if (options.skipDuplicates) {
           // skip files already imported at the same scope

--- a/index.js
+++ b/index.js
@@ -19,6 +19,7 @@ function AtImport(options) {
     load: loadContent,
     plugins: [],
     addModulesDirectories: [],
+    nameLayer: null,
     ...options,
   }
 
@@ -309,8 +310,12 @@ function AtImport(options) {
         const atRule = stmt.node
         const { media, layer } = stmt
         layer.forEach((layerPart, i) => {
-          if (layerPart === "") {
-            layer[i] = `imported-anon-layer-${state.anonymousLayerCounter++}`
+          if (layerPart === "" && options.nameLayer) {
+            layer[i] = options.nameLayer(
+              state.anonymousLayerCounter++,
+              filename,
+              stmt.node.toString()
+            )
           }
         })
 

--- a/index.js
+++ b/index.js
@@ -38,10 +38,12 @@ function AtImport(options) {
       const state = {
         importedFiles: {},
         hashFiles: {},
+        rootFilename: null,
         anonymousLayerCounter: 0,
       }
 
       if (styles.source && styles.source.input && styles.source.input.file) {
+        state.rootFilename = styles.source.input.file
         state.importedFiles[styles.source.input.file] = {}
       }
 
@@ -317,12 +319,11 @@ function AtImport(options) {
           if (layerPart === "") {
             if (options.nameLayer) {
               layer[i] = options
-                .nameLayer(state.anonymousLayerCounter++, filename)
+                .nameLayer(state.anonymousLayerCounter++, state.rootFilename)
                 .toString()
             } else {
-              result.warn(
-                `When using anonymous layers in @import you must also set the "nameLayer" plugin option`,
-                { node: atRule }
+              throw atRule.error(
+                `When using anonymous layers in @import you must also set the "nameLayer" plugin option`
               )
             }
           }

--- a/index.js
+++ b/index.js
@@ -79,21 +79,7 @@ function AtImport(options) {
           }
 
           if (stmt.type === "import") {
-            const media = stmt.media.join(", ")
-            if (stmt.layer.length) {
-              const layerName = stmt.layer
-                .filter(layer => layer !== "")
-                .join(".")
-
-              let layerParams = "layer"
-              if (layerName) {
-                layerParams = `layer(${layerName})`
-              }
-
-              stmt.node.params = `${stmt.fullUri} ${layerParams})${media}`
-            } else {
-              stmt.node.params = `${stmt.fullUri} ${media}`
-            }
+            stmt.node.params = `${stmt.fullUri} ${stmt.media.join(", ")}`
           } else if (stmt.type === "media") {
             if (stmt.layer.length) {
               const layerNode = atRule({
@@ -209,7 +195,6 @@ function AtImport(options) {
                 stmt.media = joinMedia(media, stmt.media || [])
                 stmt.parentMedia = media
                 stmt.layer = joinLayer(layer, stmt.layer || [])
-                stmt.parentLayer = layer
 
                 // skip protocol base uri (protocol://url) or protocol-relative
                 if (

--- a/index.js
+++ b/index.js
@@ -310,12 +310,19 @@ function AtImport(options) {
         const atRule = stmt.node
         const { media, layer } = stmt
         layer.forEach((layerPart, i) => {
-          if (layerPart === "" && options.nameLayer) {
-            layer[i] = options.nameLayer(
-              state.anonymousLayerCounter++,
-              filename,
-              stmt.node.toString()
-            )
+          if (layerPart === "") {
+            if (options.nameLayer) {
+              layer[i] = options.nameLayer(
+                state.anonymousLayerCounter++,
+                filename,
+                stmt.node.toString()
+              )
+            } else {
+              result.warn(
+                `When using anonymous layers in @import you must also set the "nameLayer" plugin option`,
+                { node: atRule }
+              )
+            }
           }
         })
 

--- a/index.js
+++ b/index.js
@@ -102,15 +102,20 @@ function AtImport(options) {
                 source: stmt.node.source,
               })
 
-              const mediaNode = atRule({
-                name: "media",
-                params: stmt.parentMedia.join(", "),
-                source: stmt.node.source,
-              })
+              if (stmt.parentMedia && stmt.parentMedia.length) {
+                const mediaNode = atRule({
+                  name: "media",
+                  params: stmt.parentMedia.join(", "),
+                  source: stmt.node.source,
+                })
 
-              mediaNode.append(layerNode)
-              layerNode.append(stmt.node)
-              stmt.node = mediaNode
+                mediaNode.append(layerNode)
+                layerNode.append(stmt.node)
+                stmt.node = mediaNode
+              } else {
+                layerNode.append(stmt.node)
+                stmt.node = layerNode
+              }
             } else {
               stmt.node.params = stmt.media.join(", ")
             }

--- a/index.js
+++ b/index.js
@@ -49,6 +49,10 @@ function AtImport(options) {
         throw new Error("plugins option must be an array")
       }
 
+      if (options.nameLayer && typeof options.nameLayer !== "function") {
+        throw new Error("nameLayer option must be a function")
+      }
+
       return parseStyles(result, styles, options, state, [], []).then(
         bundle => {
           applyRaws(bundle)
@@ -312,11 +316,9 @@ function AtImport(options) {
         layer.forEach((layerPart, i) => {
           if (layerPart === "") {
             if (options.nameLayer) {
-              layer[i] = options.nameLayer(
-                state.anonymousLayerCounter++,
-                filename,
-                stmt.node.toString()
-              )
+              layer[i] = options
+                .nameLayer(state.anonymousLayerCounter++, filename)
+                .toString()
             } else {
               result.warn(
                 `When using anonymous layers in @import you must also set the "nameLayer" plugin option`,

--- a/test/fixtures/imports/layer-anonymous.css
+++ b/test/fixtures/imports/layer-anonymous.css
@@ -1,0 +1,33 @@
+@import url("layer-level-2-anonymous.css") layer;
+
+body {
+  order: 1;
+}
+
+@media (min-width: 50rem) {
+  body {
+    order: 2;
+  }
+}
+
+@keyframes RED_TO_BLUE {
+  0% {
+    background-color: red;
+  }
+  100% {
+    background-color: blue;
+  }
+}
+
+@supports (display: grid) {
+  body {
+    display: grid;
+    order: 3;
+  }
+}
+
+@layer A {
+  body {
+    order: 4;
+  }
+}

--- a/test/fixtures/imports/layer-level-2-anonymous.css
+++ b/test/fixtures/imports/layer-level-2-anonymous.css
@@ -1,0 +1,7 @@
+@import url("layer-level-3.css") layer (min-width: 320px);
+
+@layer Y {
+  body {
+    color: purple;
+  }
+}

--- a/test/fixtures/imports/layer-level-2.css
+++ b/test/fixtures/imports/layer-level-2.css
@@ -1,0 +1,7 @@
+@import url("layer-level-3.css") layer(level-3) (min-width: 320px);
+
+@layer Y {
+  body {
+    color: purple;
+  }
+}

--- a/test/fixtures/imports/layer-level-3.css
+++ b/test/fixtures/imports/layer-level-3.css
@@ -1,0 +1,5 @@
+@layer Z {
+  body {
+    color: cyan;
+  }
+}

--- a/test/fixtures/imports/layer-rule-grouping.css
+++ b/test/fixtures/imports/layer-rule-grouping.css
@@ -1,0 +1,13 @@
+rule-one {}
+
+rule-two {}
+
+@media (min-width: 50rem) {
+  rule-three {}
+
+  rule-four {}
+}
+
+rule-five {}
+
+rule-six {}

--- a/test/fixtures/imports/layer.css
+++ b/test/fixtures/imports/layer.css
@@ -1,0 +1,33 @@
+@import url("layer-level-2.css") layer(level-2);
+
+body {
+  order: 1;
+}
+
+@media (min-width: 50rem) {
+  body {
+    order: 2;
+  }
+}
+
+@keyframes RED_TO_BLUE {
+  0% {
+    background-color: red;
+  }
+  100% {
+    background-color: blue;
+  }
+}
+
+@supports (display: grid) {
+  body {
+    display: grid;
+    order: 3;
+  }
+}
+
+@layer A {
+  body {
+    order: 4;
+  }
+}

--- a/test/fixtures/layer-import-atrules-anonymous.css
+++ b/test/fixtures/layer-import-atrules-anonymous.css
@@ -1,0 +1,3 @@
+@import url("layer-anonymous.css") layer screen;
+
+@import url("layer-anonymous.css") layer;

--- a/test/fixtures/layer-import-atrules-anonymous.expected.css
+++ b/test/fixtures/layer-import-atrules-anonymous.expected.css
@@ -1,0 +1,127 @@
+@media screen and (min-width: 320px) {
+@layer imported-anon-layer-0.imported-anon-layer-1.imported-anon-layer-2 {
+@layer Z {
+  body {
+    color: cyan;
+  }
+}
+}
+}
+
+@media screen {
+@layer imported-anon-layer-0.imported-anon-layer-1 {
+
+@layer Y {
+  body {
+    color: purple;
+  }
+}
+}
+}
+
+@media screen {
+@layer imported-anon-layer-0 {
+
+body {
+  order: 1;
+}
+}
+}
+
+@media screen {
+@layer imported-anon-layer-0 {
+
+@media (min-width: 50rem) {
+  body {
+    order: 2;
+  }
+}
+}
+}
+
+@media screen {
+@layer imported-anon-layer-0 {
+
+@keyframes RED_TO_BLUE {
+  0% {
+    background-color: red;
+  }
+  100% {
+    background-color: blue;
+  }
+}
+
+@supports (display: grid) {
+  body {
+    display: grid;
+    order: 3;
+  }
+}
+
+@layer A {
+  body {
+    order: 4;
+  }
+}
+}
+}
+
+@media (min-width: 320px) {
+@layer imported-anon-layer-3.imported-anon-layer-4.imported-anon-layer-5 {
+@layer Z {
+  body {
+    color: cyan;
+  }
+}
+}
+}
+
+@layer imported-anon-layer-3.imported-anon-layer-4 {
+
+@layer Y {
+  body {
+    color: purple;
+  }
+}
+}
+
+@layer imported-anon-layer-3 {
+
+body {
+  order: 1;
+}
+}
+
+@layer imported-anon-layer-3 {
+
+@media (min-width: 50rem) {
+  body {
+    order: 2;
+  }
+}
+}
+
+@layer imported-anon-layer-3 {
+
+@keyframes RED_TO_BLUE {
+  0% {
+    background-color: red;
+  }
+  100% {
+    background-color: blue;
+  }
+}
+
+@supports (display: grid) {
+  body {
+    display: grid;
+    order: 3;
+  }
+}
+
+@layer A {
+  body {
+    order: 4;
+  }
+}
+}

--- a/test/fixtures/layer-import-atrules-anonymous.expected.css
+++ b/test/fixtures/layer-import-atrules-anonymous.expected.css
@@ -1,5 +1,5 @@
 @media screen and (min-width: 320px) {
-@layer import-anon-layer-20276dc93dc7.import-anon-layer-7e2a133c7301.import-anon-layer-fad0feff5ad9 {
+@layer import-anon-layer-ee0eb586e3cb.import-anon-layer-1c6bcc6a6840.import-anon-layer-c28eb28fcb9e {
 @layer Z {
   body {
     color: cyan;
@@ -9,7 +9,7 @@
 }
 
 @media screen {
-@layer import-anon-layer-20276dc93dc7.import-anon-layer-7e2a133c7301 {
+@layer import-anon-layer-ee0eb586e3cb.import-anon-layer-1c6bcc6a6840 {
 
 @layer Y {
   body {
@@ -20,7 +20,7 @@
 }
 
 @media screen {
-@layer import-anon-layer-20276dc93dc7 {
+@layer import-anon-layer-ee0eb586e3cb {
 
 body {
   order: 1;
@@ -29,7 +29,7 @@ body {
 }
 
 @media screen {
-@layer import-anon-layer-20276dc93dc7 {
+@layer import-anon-layer-ee0eb586e3cb {
 
 @media (min-width: 50rem) {
   body {
@@ -40,7 +40,7 @@ body {
 }
 
 @media screen {
-@layer import-anon-layer-20276dc93dc7 {
+@layer import-anon-layer-ee0eb586e3cb {
 
 @keyframes RED_TO_BLUE {
   0% {
@@ -67,7 +67,7 @@ body {
 }
 
 @media (min-width: 320px) {
-@layer import-anon-layer-247d69ad0e54.import-anon-layer-1cac8a74ff2c.import-anon-layer-33665317f72a {
+@layer import-anon-layer-8aab87a450d5.import-anon-layer-b0405b84e857.import-anon-layer-77a87e054b81 {
 @layer Z {
   body {
     color: cyan;
@@ -76,7 +76,7 @@ body {
 }
 }
 
-@layer import-anon-layer-247d69ad0e54.import-anon-layer-1cac8a74ff2c {
+@layer import-anon-layer-8aab87a450d5.import-anon-layer-b0405b84e857 {
 
 @layer Y {
   body {
@@ -85,14 +85,14 @@ body {
 }
 }
 
-@layer import-anon-layer-247d69ad0e54 {
+@layer import-anon-layer-8aab87a450d5 {
 
 body {
   order: 1;
 }
 }
 
-@layer import-anon-layer-247d69ad0e54 {
+@layer import-anon-layer-8aab87a450d5 {
 
 @media (min-width: 50rem) {
   body {
@@ -101,7 +101,7 @@ body {
 }
 }
 
-@layer import-anon-layer-247d69ad0e54 {
+@layer import-anon-layer-8aab87a450d5 {
 
 @keyframes RED_TO_BLUE {
   0% {

--- a/test/fixtures/layer-import-atrules-anonymous.expected.css
+++ b/test/fixtures/layer-import-atrules-anonymous.expected.css
@@ -1,5 +1,5 @@
 @media screen and (min-width: 320px) {
-@layer imported-anon-layer-0.imported-anon-layer-1.imported-anon-layer-2 {
+@layer import-anon-layer-20276dc93dc7.import-anon-layer-7e2a133c7301.import-anon-layer-fad0feff5ad9 {
 @layer Z {
   body {
     color: cyan;
@@ -9,7 +9,7 @@
 }
 
 @media screen {
-@layer imported-anon-layer-0.imported-anon-layer-1 {
+@layer import-anon-layer-20276dc93dc7.import-anon-layer-7e2a133c7301 {
 
 @layer Y {
   body {
@@ -20,7 +20,7 @@
 }
 
 @media screen {
-@layer imported-anon-layer-0 {
+@layer import-anon-layer-20276dc93dc7 {
 
 body {
   order: 1;
@@ -29,7 +29,7 @@ body {
 }
 
 @media screen {
-@layer imported-anon-layer-0 {
+@layer import-anon-layer-20276dc93dc7 {
 
 @media (min-width: 50rem) {
   body {
@@ -40,7 +40,7 @@ body {
 }
 
 @media screen {
-@layer imported-anon-layer-0 {
+@layer import-anon-layer-20276dc93dc7 {
 
 @keyframes RED_TO_BLUE {
   0% {
@@ -67,7 +67,7 @@ body {
 }
 
 @media (min-width: 320px) {
-@layer imported-anon-layer-3.imported-anon-layer-4.imported-anon-layer-5 {
+@layer import-anon-layer-247d69ad0e54.import-anon-layer-1cac8a74ff2c.import-anon-layer-33665317f72a {
 @layer Z {
   body {
     color: cyan;
@@ -76,7 +76,7 @@ body {
 }
 }
 
-@layer imported-anon-layer-3.imported-anon-layer-4 {
+@layer import-anon-layer-247d69ad0e54.import-anon-layer-1cac8a74ff2c {
 
 @layer Y {
   body {
@@ -85,14 +85,14 @@ body {
 }
 }
 
-@layer imported-anon-layer-3 {
+@layer import-anon-layer-247d69ad0e54 {
 
 body {
   order: 1;
 }
 }
 
-@layer imported-anon-layer-3 {
+@layer import-anon-layer-247d69ad0e54 {
 
 @media (min-width: 50rem) {
   body {
@@ -101,7 +101,7 @@ body {
 }
 }
 
-@layer imported-anon-layer-3 {
+@layer import-anon-layer-247d69ad0e54 {
 
 @keyframes RED_TO_BLUE {
   0% {

--- a/test/fixtures/layer-import-atrules-anonymous.expected.css
+++ b/test/fixtures/layer-import-atrules-anonymous.expected.css
@@ -1,5 +1,5 @@
 @media screen and (min-width: 320px) {
-@layer import-anon-layer-ee0eb586e3cb.import-anon-layer-1c6bcc6a6840.import-anon-layer-c28eb28fcb9e {
+@layer import-anon-layer-0.import-anon-layer-1.import-anon-layer-2 {
 @layer Z {
   body {
     color: cyan;
@@ -9,7 +9,7 @@
 }
 
 @media screen {
-@layer import-anon-layer-ee0eb586e3cb.import-anon-layer-1c6bcc6a6840 {
+@layer import-anon-layer-0.import-anon-layer-1 {
 
 @layer Y {
   body {
@@ -20,7 +20,7 @@
 }
 
 @media screen {
-@layer import-anon-layer-ee0eb586e3cb {
+@layer import-anon-layer-0 {
 
 body {
   order: 1;
@@ -29,7 +29,7 @@ body {
 }
 
 @media screen {
-@layer import-anon-layer-ee0eb586e3cb {
+@layer import-anon-layer-0 {
 
 @media (min-width: 50rem) {
   body {
@@ -40,7 +40,7 @@ body {
 }
 
 @media screen {
-@layer import-anon-layer-ee0eb586e3cb {
+@layer import-anon-layer-0 {
 
 @keyframes RED_TO_BLUE {
   0% {
@@ -67,7 +67,7 @@ body {
 }
 
 @media (min-width: 320px) {
-@layer import-anon-layer-8aab87a450d5.import-anon-layer-b0405b84e857.import-anon-layer-77a87e054b81 {
+@layer import-anon-layer-3.import-anon-layer-4.import-anon-layer-5 {
 @layer Z {
   body {
     color: cyan;
@@ -76,7 +76,7 @@ body {
 }
 }
 
-@layer import-anon-layer-8aab87a450d5.import-anon-layer-b0405b84e857 {
+@layer import-anon-layer-3.import-anon-layer-4 {
 
 @layer Y {
   body {
@@ -85,14 +85,14 @@ body {
 }
 }
 
-@layer import-anon-layer-8aab87a450d5 {
+@layer import-anon-layer-3 {
 
 body {
   order: 1;
 }
 }
 
-@layer import-anon-layer-8aab87a450d5 {
+@layer import-anon-layer-3 {
 
 @media (min-width: 50rem) {
   body {
@@ -101,7 +101,7 @@ body {
 }
 }
 
-@layer import-anon-layer-8aab87a450d5 {
+@layer import-anon-layer-3 {
 
 @keyframes RED_TO_BLUE {
   0% {

--- a/test/fixtures/layer-import-atrules.css
+++ b/test/fixtures/layer-import-atrules.css
@@ -1,1 +1,3 @@
-@import url("layer.css") layer(imported) screen;
+@import url("layer.css") layer(imported-with-media) screen;
+
+@import url("layer.css") layer(imported-without-media);

--- a/test/fixtures/layer-import-atrules.css
+++ b/test/fixtures/layer-import-atrules.css
@@ -1,0 +1,1 @@
+@import url("layer.css") layer(imported) screen;

--- a/test/fixtures/layer-import-atrules.expected.css
+++ b/test/fixtures/layer-import-atrules.expected.css
@@ -1,0 +1,67 @@
+@media screen and (min-width: 320px) {
+    @layer imported.level-2.level-3 {
+@layer Z {
+  body {
+    color: cyan;
+  }
+}
+    }
+}
+
+@media screen {
+    @layer imported.level-2 {
+
+@layer Y {
+  body {
+    color: purple;
+  }
+}
+    }
+}
+
+@media screen {
+    @layer imported {
+
+body {
+  order: 1;
+}
+    }
+}
+
+@media screen {
+    @layer imported {
+
+@media (min-width: 50rem) {
+  body {
+    order: 2;
+  }
+}
+    }
+}
+
+@media screen {
+    @layer imported {
+
+@keyframes RED_TO_BLUE {
+  0% {
+    background-color: red;
+  }
+  100% {
+    background-color: blue;
+  }
+}
+
+@supports (display: grid) {
+  body {
+    display: grid;
+    order: 3;
+  }
+}
+
+@layer A {
+  body {
+    order: 4;
+  }
+}
+    }
+}

--- a/test/fixtures/layer-import-atrules.expected.css
+++ b/test/fixtures/layer-import-atrules.expected.css
@@ -1,46 +1,46 @@
 @media screen and (min-width: 320px) {
-    @layer imported.level-2.level-3 {
+@layer imported-with-media.level-2.level-3 {
 @layer Z {
   body {
     color: cyan;
   }
 }
-    }
+}
 }
 
 @media screen {
-    @layer imported.level-2 {
+@layer imported-with-media.level-2 {
 
 @layer Y {
   body {
     color: purple;
   }
 }
-    }
+}
 }
 
 @media screen {
-    @layer imported {
+@layer imported-with-media {
 
 body {
   order: 1;
 }
-    }
+}
 }
 
 @media screen {
-    @layer imported {
+@layer imported-with-media {
 
 @media (min-width: 50rem) {
   body {
     order: 2;
   }
 }
-    }
+}
 }
 
 @media screen {
-    @layer imported {
+@layer imported-with-media {
 
 @keyframes RED_TO_BLUE {
   0% {
@@ -63,5 +63,65 @@ body {
     order: 4;
   }
 }
-    }
+}
+}
+
+@media (min-width: 320px) {
+@layer imported-without-media.level-2.level-3 {
+@layer Z {
+  body {
+    color: cyan;
+  }
+}
+}
+}
+
+@layer imported-without-media.level-2 {
+
+@layer Y {
+  body {
+    color: purple;
+  }
+}
+}
+
+@layer imported-without-media {
+
+body {
+  order: 1;
+}
+}
+
+@layer imported-without-media {
+
+@media (min-width: 50rem) {
+  body {
+    order: 2;
+  }
+}
+}
+
+@layer imported-without-media {
+
+@keyframes RED_TO_BLUE {
+  0% {
+    background-color: red;
+  }
+  100% {
+    background-color: blue;
+  }
+}
+
+@supports (display: grid) {
+  body {
+    display: grid;
+    order: 3;
+  }
+}
+
+@layer A {
+  body {
+    order: 4;
+  }
+}
 }

--- a/test/fixtures/layer-rule-grouping.css
+++ b/test/fixtures/layer-rule-grouping.css
@@ -1,0 +1,6 @@
+@import url("layer-rule-grouping.css") screen;
+
+@import url("layer-rule-grouping.css") layer;
+@import url("layer-rule-grouping.css") layer;
+
+@import url("layer-rule-grouping.css") layer(named);

--- a/test/fixtures/layer-rule-grouping.expected.css
+++ b/test/fixtures/layer-rule-grouping.expected.css
@@ -18,14 +18,14 @@ rule-five {}
 rule-six {}
 }
 
-@layer importted-anon-layer-0 {
+@layer imported-anon-layer-0 {
 
 rule-one {}
 
 rule-two {}
 }
 
-@layer importted-anon-layer-0 {
+@layer imported-anon-layer-0 {
 
 @media (min-width: 50rem) {
   rule-three {}
@@ -34,21 +34,21 @@ rule-two {}
 }
 }
 
-@layer importted-anon-layer-0 {
+@layer imported-anon-layer-0 {
 
 rule-five {}
 
 rule-six {}
 }
 
-@layer importted-anon-layer-1 {
+@layer imported-anon-layer-1 {
 
 rule-one {}
 
 rule-two {}
 }
 
-@layer importted-anon-layer-1 {
+@layer imported-anon-layer-1 {
 
 @media (min-width: 50rem) {
   rule-three {}
@@ -57,7 +57,7 @@ rule-two {}
 }
 }
 
-@layer importted-anon-layer-1 {
+@layer imported-anon-layer-1 {
 
 rule-five {}
 

--- a/test/fixtures/layer-rule-grouping.expected.css
+++ b/test/fixtures/layer-rule-grouping.expected.css
@@ -18,14 +18,14 @@ rule-five {}
 rule-six {}
 }
 
-@layer imported-anon-layer-0 {
+@layer import-anon-layer-b9a4ee60a544 {
 
 rule-one {}
 
 rule-two {}
 }
 
-@layer imported-anon-layer-0 {
+@layer import-anon-layer-b9a4ee60a544 {
 
 @media (min-width: 50rem) {
   rule-three {}
@@ -34,21 +34,21 @@ rule-two {}
 }
 }
 
-@layer imported-anon-layer-0 {
+@layer import-anon-layer-b9a4ee60a544 {
 
 rule-five {}
 
 rule-six {}
 }
 
-@layer imported-anon-layer-1 {
+@layer import-anon-layer-c81ed089cee2 {
 
 rule-one {}
 
 rule-two {}
 }
 
-@layer imported-anon-layer-1 {
+@layer import-anon-layer-c81ed089cee2 {
 
 @media (min-width: 50rem) {
   rule-three {}
@@ -57,7 +57,7 @@ rule-two {}
 }
 }
 
-@layer imported-anon-layer-1 {
+@layer import-anon-layer-c81ed089cee2 {
 
 rule-five {}
 

--- a/test/fixtures/layer-rule-grouping.expected.css
+++ b/test/fixtures/layer-rule-grouping.expected.css
@@ -1,0 +1,88 @@
+@media screen {
+
+rule-one {}
+
+rule-two {}
+}
+
+@media screen and (min-width: 50rem) {
+  rule-three {}
+
+  rule-four {}
+}
+
+@media screen {
+
+rule-five {}
+
+rule-six {}
+}
+
+@layer importted-anon-layer-0 {
+
+rule-one {}
+
+rule-two {}
+}
+
+@layer importted-anon-layer-0 {
+
+@media (min-width: 50rem) {
+  rule-three {}
+
+  rule-four {}
+}
+}
+
+@layer importted-anon-layer-0 {
+
+rule-five {}
+
+rule-six {}
+}
+
+@layer importted-anon-layer-1 {
+
+rule-one {}
+
+rule-two {}
+}
+
+@layer importted-anon-layer-1 {
+
+@media (min-width: 50rem) {
+  rule-three {}
+
+  rule-four {}
+}
+}
+
+@layer importted-anon-layer-1 {
+
+rule-five {}
+
+rule-six {}
+}
+
+@layer named {
+
+rule-one {}
+
+rule-two {}
+}
+
+@layer named {
+
+@media (min-width: 50rem) {
+  rule-three {}
+
+  rule-four {}
+}
+}
+
+@layer named {
+
+rule-five {}
+
+rule-six {}
+}

--- a/test/fixtures/layer-rule-grouping.expected.css
+++ b/test/fixtures/layer-rule-grouping.expected.css
@@ -18,14 +18,14 @@ rule-five {}
 rule-six {}
 }
 
-@layer import-anon-layer-64359fd6446a {
+@layer import-anon-layer-0 {
 
 rule-one {}
 
 rule-two {}
 }
 
-@layer import-anon-layer-64359fd6446a {
+@layer import-anon-layer-0 {
 
 @media (min-width: 50rem) {
   rule-three {}
@@ -34,21 +34,21 @@ rule-two {}
 }
 }
 
-@layer import-anon-layer-64359fd6446a {
+@layer import-anon-layer-0 {
 
 rule-five {}
 
 rule-six {}
 }
 
-@layer import-anon-layer-47b84b25cc00 {
+@layer import-anon-layer-1 {
 
 rule-one {}
 
 rule-two {}
 }
 
-@layer import-anon-layer-47b84b25cc00 {
+@layer import-anon-layer-1 {
 
 @media (min-width: 50rem) {
   rule-three {}
@@ -57,7 +57,7 @@ rule-two {}
 }
 }
 
-@layer import-anon-layer-47b84b25cc00 {
+@layer import-anon-layer-1 {
 
 rule-five {}
 

--- a/test/fixtures/layer-rule-grouping.expected.css
+++ b/test/fixtures/layer-rule-grouping.expected.css
@@ -18,14 +18,14 @@ rule-five {}
 rule-six {}
 }
 
-@layer import-anon-layer-b9a4ee60a544 {
+@layer import-anon-layer-64359fd6446a {
 
 rule-one {}
 
 rule-two {}
 }
 
-@layer import-anon-layer-b9a4ee60a544 {
+@layer import-anon-layer-64359fd6446a {
 
 @media (min-width: 50rem) {
   rule-three {}
@@ -34,21 +34,21 @@ rule-two {}
 }
 }
 
-@layer import-anon-layer-b9a4ee60a544 {
+@layer import-anon-layer-64359fd6446a {
 
 rule-five {}
 
 rule-six {}
 }
 
-@layer import-anon-layer-c81ed089cee2 {
+@layer import-anon-layer-47b84b25cc00 {
 
 rule-one {}
 
 rule-two {}
 }
 
-@layer import-anon-layer-c81ed089cee2 {
+@layer import-anon-layer-47b84b25cc00 {
 
 @media (min-width: 50rem) {
   rule-three {}
@@ -57,7 +57,7 @@ rule-two {}
 }
 }
 
-@layer import-anon-layer-c81ed089cee2 {
+@layer import-anon-layer-47b84b25cc00 {
 
 rule-five {}
 

--- a/test/fixtures/layer.css
+++ b/test/fixtures/layer.css
@@ -1,9 +1,9 @@
 @layer layer-alpha, layer-beta.one;
 
-@import "foo.css" layer;
+@import "foo.css" layer(foo);
 @import 'bar.css' layer(bar);
 @import 'bar.css' layer(bar) level-1 and level-2;
-@import url(baz.css) layer;
+@import url(baz.css) layer(baz);
 @import url("foobar.css") layer(foobar);
 @import url("foo-layered.css") layer(foo-layered);
 

--- a/test/fixtures/layer.expected.css
+++ b/test/fixtures/layer.expected.css
@@ -1,5 +1,5 @@
 @layer layer-alpha, layer-beta.one;
-@layer{
+@layer importted-anon-layer-0{
 foo{}
 }
 @layer bar{
@@ -10,7 +10,7 @@ bar{}
 bar{}
 }
 }
-@layer{
+@layer importted-anon-layer-1{
 baz{}
 }
 @layer foobar{

--- a/test/fixtures/layer.expected.css
+++ b/test/fixtures/layer.expected.css
@@ -1,5 +1,5 @@
 @layer layer-alpha, layer-beta.one;
-@layer import-anon-layer-02e61fe44938{
+@layer foo{
 foo{}
 }
 @layer bar{
@@ -10,7 +10,7 @@ bar{}
 bar{}
 }
 }
-@layer import-anon-layer-c204a013b5b6{
+@layer baz{
 baz{}
 }
 @layer foobar{

--- a/test/fixtures/layer.expected.css
+++ b/test/fixtures/layer.expected.css
@@ -1,5 +1,5 @@
 @layer layer-alpha, layer-beta.one;
-@layer importted-anon-layer-0{
+@layer imported-anon-layer-0{
 foo{}
 }
 @layer bar{
@@ -10,7 +10,7 @@ bar{}
 bar{}
 }
 }
-@layer importted-anon-layer-1{
+@layer imported-anon-layer-1{
 baz{}
 }
 @layer foobar{

--- a/test/fixtures/layer.expected.css
+++ b/test/fixtures/layer.expected.css
@@ -1,5 +1,5 @@
 @layer layer-alpha, layer-beta.one;
-@layer imported-anon-layer-0{
+@layer import-anon-layer-02e61fe44938{
 foo{}
 }
 @layer bar{
@@ -10,7 +10,7 @@ bar{}
 bar{}
 }
 }
-@layer imported-anon-layer-1{
+@layer import-anon-layer-c204a013b5b6{
 baz{}
 }
 @layer foobar{

--- a/test/layer.js
+++ b/test/layer.js
@@ -13,4 +13,10 @@ test(
   "layer-import-atrules"
 )
 
+test(
+  "should correctly wrap imported at rules in anonymous layers",
+  checkFixture,
+  "layer-import-atrules-anonymous"
+)
+
 test("should group rules", checkFixture, "layer-rule-grouping")

--- a/test/layer.js
+++ b/test/layer.js
@@ -1,15 +1,18 @@
 "use strict"
 // external tooling
 const test = require("ava")
+const postcss = require("postcss")
+
 const crypto = require("crypto")
 const cwd = process.cwd()
+
+// plugin
+const atImport = require("..")
 
 // internal tooling
 const checkFixture = require("./helpers/check-fixture")
 
-test("should resolve layers of import statements", checkFixture, "layer", {
-  nameLayer: hashLayerName,
-})
+test("should resolve layers of import statements", checkFixture, "layer")
 
 test(
   "should correctly wrap imported at rules in layers",
@@ -33,14 +36,34 @@ test("should group rules", checkFixture, "layer-rule-grouping", {
   nameLayer: hashLayerName,
 })
 
-function hashLayerName(index, filename, importRule) {
+test("should error when value is not a function", t => {
+  return postcss()
+    .use(atImport({ nameLayer: "not a function" }))
+    .process("", { from: undefined })
+    .catch(error => t.is(error.message, "nameLayer option must be a function"))
+})
+
+test("should warn when using anonymous layers without the nameLayer plugin option", t => {
+  return postcss()
+    .use(atImport({ path: "test/fixtures/imports" }))
+    .process('@import "foo.css" layer;', { from: undefined })
+    .then(result => {
+      const warnings = result.warnings()
+      t.is(warnings.length, 1)
+      t.is(
+        warnings[0].text,
+        'When using anonymous layers in @import you must also set the "nameLayer" plugin option'
+      )
+    })
+})
+
+function hashLayerName(index, filename) {
   // A stable, deterministic and unique layer name:
   // - layer index
   // - relative filename to current working directory
-  // - import rule source
   return `import-anon-layer-${crypto
     .createHash("sha256")
-    .update(`${index}-${filename.split(cwd)[1]}-${importRule}`)
+    .update(`${index}-${filename.split(cwd)[1]}`)
     .digest("hex")
     .slice(0, 12)}`
 }

--- a/test/layer.js
+++ b/test/layer.js
@@ -12,3 +12,5 @@ test(
   checkFixture,
   "layer-import-atrules"
 )
+
+test("should group rules", checkFixture, "layer-rule-grouping")

--- a/test/layer.js
+++ b/test/layer.js
@@ -1,22 +1,42 @@
 "use strict"
 // external tooling
 const test = require("ava")
+const crypto = require("crypto")
+const cwd = process.cwd()
 
 // internal tooling
 const checkFixture = require("./helpers/check-fixture")
 
-test("should resolve layers of import statements", checkFixture, "layer")
+test("should resolve layers of import statements", checkFixture, "layer", {
+  nameLayer: hashLayerName,
+})
 
 test(
   "should correctly wrap imported at rules in layers",
   checkFixture,
-  "layer-import-atrules"
+  "layer-import-atrules",
+  {
+    nameLayer: hashLayerName,
+  }
 )
 
 test(
   "should correctly wrap imported at rules in anonymous layers",
   checkFixture,
-  "layer-import-atrules-anonymous"
+  "layer-import-atrules-anonymous",
+  {
+    nameLayer: hashLayerName,
+  }
 )
 
-test("should group rules", checkFixture, "layer-rule-grouping")
+test("should group rules", checkFixture, "layer-rule-grouping", {
+  nameLayer: hashLayerName,
+})
+
+function hashLayerName(index, filename, importRule) {
+  return `import-anon-layer-${crypto
+    .createHash("sha256")
+    .update(`${index}-${filename.split(cwd)[1]}-${importRule}`)
+    .digest("hex")
+    .slice(0, 12)}`
+}

--- a/test/layer.js
+++ b/test/layer.js
@@ -6,3 +6,9 @@ const test = require("ava")
 const checkFixture = require("./helpers/check-fixture")
 
 test("should resolve layers of import statements", checkFixture, "layer")
+
+test(
+  "should correctly wrap imported at rules in layers",
+  checkFixture,
+  "layer-import-atrules"
+)

--- a/test/layer.js
+++ b/test/layer.js
@@ -34,6 +34,10 @@ test("should group rules", checkFixture, "layer-rule-grouping", {
 })
 
 function hashLayerName(index, filename, importRule) {
+  // A stable, deterministic and unique layer name:
+  // - layer index
+  // - relative filename to current working directory
+  // - import rule source
   return `import-anon-layer-${crypto
     .createHash("sha256")
     .update(`${index}-${filename.split(cwd)[1]}-${importRule}`)


### PR DESCRIPTION
fixes : https://github.com/postcss/postcss-import/issues/495

@RyanZim it still feels a bit like the complexity (which I added) is exploding and the overal shape of the code base isn't optimal. But I also do not dislike this fix :)

Important spec bits : https://www.w3.org/TR/css-cascade-5/#at-import

> the optional layer keyword or layer() function assigns the contents of the style sheet into its own anonymous [cascade layer](https://www.w3.org/TR/css-cascade-5/#cascade-layers) or into the named cascade layer.
>
>The layer is added to the [layer order](https://www.w3.org/TR/css-cascade-5/#layer-ordering) even if the import fails to load the stylesheet, but is subject to any [import conditions](https://www.w3.org/TR/css-cascade-5/#import-conditions) (just as if declared by an [@layer](https://www.w3.org/TR/css-cascade-5/#at-ruledef-layer) rule wrapped in the appropriate [conditional group rules](https://www.w3.org/TR/css3-conditional/#conditional-group-rule)).the optional layer keyword or layer() function assigns the contents of the style sheet into its own anonymous [cascade layer](https://www.w3.org/TR/css-cascade-5/#cascade-layers) or into the named cascade layer.
>
>The layer is added to the [layer order](https://www.w3.org/TR/css-cascade-5/#layer-ordering) even if the import fails to load the stylesheet, but is subject to any [import conditions](https://www.w3.org/TR/css-cascade-5/#import-conditions) (just as if declared by an [@layer](https://www.w3.org/TR/css-cascade-5/#at-ruledef-layer) rule wrapped in the appropriate [conditional group rules](https://www.w3.org/TR/css3-conditional/#conditional-group-rule)).

Which means that `@import url('foo.css') layer(A) (min-width: 320px)` becomes :

```css
@media (min-width: 320px) {
  @layer A {
    /* imported styles */
  }
}