### PR TITLE
preserve `layer` in ignored `@imports` statements

### DIFF
--- a/lib/assign-layer-names.js
+++ b/lib/assign-layer-names.js
@@ -1,0 +1,17 @@
+"use strict"
+
+module.exports = function (layer, node, state, options) {
+  layer.forEach((layerPart, i) => {
+    if (layerPart.trim() === "") {
+      if (options.nameLayer) {
+        layer[i] = options
+          .nameLayer(state.anonymousLayerCounter++, state.rootFilename)
+          .toString()
+      } else {
+        throw node.error(
+          `When using anonymous layers in @import you must also set the "nameLayer" plugin option`
+        )
+      }
+    }
+  })
+}

--- a/test/fixtures/ignore.css
+++ b/test/fixtures/ignore.css
@@ -12,5 +12,9 @@
 @import url("//css");
 @import url('//css');
 @import url(//css);
+@import "http://css" layer;
+@import "http://css" layer(bar);
+@import "http://css" layer screen and (min-width: 25em), print;
+@import "http://css" layer(bar) screen and (min-width: 25em), print;
 
 content{}

--- a/test/fixtures/ignore.expected.css
+++ b/test/fixtures/ignore.expected.css
@@ -13,6 +13,10 @@
 @import url("//css");
 @import url('//css');
 @import url(//css);
+@import "http://css" layer;
+@import "http://css" layer(bar);
+@import "http://css" layer screen and (min-width: 25em), print;
+@import "http://css" layer(bar) screen and (min-width: 25em), print;
 @media (min-width: 25em){
 ignore{}
 }

--- a/test/fixtures/imports/layer-level-2-anonymous.css
+++ b/test/fixtures/imports/layer-level-2-anonymous.css
@@ -1,3 +1,5 @@
+@import "http://css" layer;
+@import "http://css-bar" layer(bar);
 @import url("layer-level-3.css") layer (min-width: 320px);
 
 @layer Y {

--- a/test/fixtures/layer-import-atrules-anonymous.css
+++ b/test/fixtures/layer-import-atrules-anonymous.css
@@ -1,3 +1,7 @@
 @import url("layer-anonymous.css") layer screen;
 
 @import url("layer-anonymous.css") layer;
+
+@import url("layer-anonymous.css") layer(named-layer-1);
+
+@import "http://css-top-level" layer;

--- a/test/fixtures/layer-import-atrules-anonymous.expected.css
+++ b/test/fixtures/layer-import-atrules-anonymous.expected.css
@@ -1,5 +1,12 @@
-@media screen and (min-width: 320px) {
-@layer import-anon-layer-0.import-anon-layer-1.import-anon-layer-2 {
+@import "http://css" layer(import-anon-layer-0.import-anon-layer-1.import-anon-layer-8) screen;
+@import "http://css-bar" layer(import-anon-layer-0.import-anon-layer-1.bar) screen;
+@import "http://css" layer(import-anon-layer-3.import-anon-layer-4.import-anon-layer-9);
+@import "http://css-bar" layer(import-anon-layer-3.import-anon-layer-4.bar);
+@import "http://css" layer(named-layer-1.import-anon-layer-6.import-anon-layer-10);
+@import "http://css-bar" layer(named-layer-1.import-anon-layer-6.bar);
+@import "http://css-top-level" layer;
+@media screen and (min-width: 320px){
+@layer import-anon-layer-0.import-anon-layer-1.import-anon-layer-2{
 @layer Z {
   body {
     color: cyan;
@@ -7,9 +14,8 @@
 }
 }
 }
-
-@media screen {
-@layer import-anon-layer-0.import-anon-layer-1 {
+@media screen{
+@layer import-anon-layer-0.import-anon-layer-1{
 
 @layer Y {
   body {
@@ -18,18 +24,16 @@
 }
 }
 }
-
-@media screen {
-@layer import-anon-layer-0 {
+@media screen{
+@layer import-anon-layer-0{
 
 body {
   order: 1;
 }
 }
 }
-
-@media screen {
-@layer import-anon-layer-0 {
+@media screen{
+@layer import-anon-layer-0{
 
 @media (min-width: 50rem) {
   body {
@@ -38,9 +42,8 @@ body {
 }
 }
 }
-
-@media screen {
-@layer import-anon-layer-0 {
+@media screen{
+@layer import-anon-layer-0{
 
 @keyframes RED_TO_BLUE {
   0% {
@@ -65,9 +68,8 @@ body {
 }
 }
 }
-
-@media (min-width: 320px) {
-@layer import-anon-layer-3.import-anon-layer-4.import-anon-layer-5 {
+@media (min-width: 320px){
+@layer import-anon-layer-3.import-anon-layer-4.import-anon-layer-5{
 @layer Z {
   body {
     color: cyan;
@@ -75,8 +77,7 @@ body {
 }
 }
 }
-
-@layer import-anon-layer-3.import-anon-layer-4 {
+@layer import-anon-layer-3.import-anon-layer-4{
 
 @layer Y {
   body {
@@ -84,15 +85,13 @@ body {
   }
 }
 }
-
-@layer import-anon-layer-3 {
+@layer import-anon-layer-3{
 
 body {
   order: 1;
 }
 }
-
-@layer import-anon-layer-3 {
+@layer import-anon-layer-3{
 
 @media (min-width: 50rem) {
   body {
@@ -100,8 +99,62 @@ body {
   }
 }
 }
+@layer import-anon-layer-3{
 
-@layer import-anon-layer-3 {
+@keyframes RED_TO_BLUE {
+  0% {
+    background-color: red;
+  }
+  100% {
+    background-color: blue;
+  }
+}
+
+@supports (display: grid) {
+  body {
+    display: grid;
+    order: 3;
+  }
+}
+
+@layer A {
+  body {
+    order: 4;
+  }
+}
+}
+@media (min-width: 320px){
+@layer named-layer-1.import-anon-layer-6.import-anon-layer-7{
+@layer Z {
+  body {
+    color: cyan;
+  }
+}
+}
+}
+@layer named-layer-1.import-anon-layer-6{
+
+@layer Y {
+  body {
+    color: purple;
+  }
+}
+}
+@layer named-layer-1{
+
+body {
+  order: 1;
+}
+}
+@layer named-layer-1{
+
+@media (min-width: 50rem) {
+  body {
+    order: 2;
+  }
+}
+}
+@layer named-layer-1{
 
 @keyframes RED_TO_BLUE {
   0% {


### PR DESCRIPTION
fix : #510

- preserves `layer` when writing `@import` rules
- correctly "concats" layers for `@import` rules

@argyleink Can you also take a look at this?