### PR TITLE
preserve invalid nodes after warnings

### DIFF
--- a/lib/parse-statements.js
+++ b/lib/parse-statements.js
@@ -70,9 +70,10 @@ function parseMedia(result, atRule) {
 
 function parseCharset(result, atRule) {
   if (atRule.prev()) {
-    return result.warn("@charset must precede all other statements", {
+    result.warn("@charset must precede all other statements", {
       node: atRule,
     })
+    return
   }
   return {
     type: "charset",
@@ -93,21 +94,23 @@ function parseImport(result, atRule) {
             prev.name !== "charset" &&
             !(prev.name === "layer" && !prev.nodes)))
       ) {
-        return result.warn(
+        result.warn(
           "@import must precede all other statements (besides @charset or empty @layer)",
           { node: atRule }
         )
+        return
       }
       prev = prev.prev()
     } while (prev)
   }
 
   if (atRule.nodes) {
-    return result.warn(
+    result.warn(
       "It looks like you didn't end your @import statement correctly. " +
         "Child nodes are attached to it.",
       { node: atRule }
     )
+    return
   }
 
   const params = valueParser(atRule.params).nodes
@@ -132,9 +135,10 @@ function parseImport(result, atRule) {
       !params[0].nodes[0].value
     )
   ) {
-    return result.warn(`Unable to find uri in '${  atRule.toString()  }'`, {
+    result.warn(`Unable to find uri in '${  atRule.toString()  }'`, {
       node: atRule,
     })
+    return
   }
 
   if (params[0].type === "string") stmt.uri = params[0].value
@@ -148,7 +152,8 @@ function parseImport(result, atRule) {
       remainder[2].value === "layer"
     ) {
       if (remainder[1].type !== "space") {
-        return result.warn("Invalid import layer statement", { node: atRule })
+        result.warn("Invalid import layer statement", { node: atRule })
+        return
       }
 
       if (remainder[2].nodes) {
@@ -162,7 +167,8 @@ function parseImport(result, atRule) {
 
   if (remainder.length > 2) {
     if (remainder[1].type !== "space") {
-      return result.warn("Invalid import media statement", { node: atRule })
+      result.warn("Invalid import media statement", { node: atRule })
+      return
     }
 
     stmt.media = split(remainder, 2)

--- a/test/lint.js
+++ b/test/lint.js
@@ -9,11 +9,15 @@ const atImport = require("..")
 const processor = postcss().use(atImport())
 
 test("should warn when not @charset and not @import statement before", t => {
+  const expects = ['a {} @import "";', '@media {} @import "";']
+
   return Promise.all([
     processor.process(`a {} @import "";`, { from: undefined }),
     processor.process(`@media {} @import "";`, { from: undefined }),
   ]).then(results => {
-    results.forEach(result => {
+    results.forEach((result, index) => {
+      t.is(result.css, expects[index])
+
       const warnings = result.warnings()
       t.is(warnings.length, 1)
       t.is(


### PR DESCRIPTION
related to : https://github.com/postcss/postcss-import/issues/509

The current implementation removes nodes which are incorrect and emits a warning.
The result is a valid CSS file but its contents are likely not what the author intended.

This change preserves the invalid rules.
The result is now an invalid CSS file but it it can be inspected more easily.
It can be confusing to have a warning about incorrectly ordered `@import` statements if the final output doesn't even contain any `@import`.

I don't have any strong opinion about what is more correct/helpful here.

If error handling is considered part of the API of this plugin then this would be a breaking change.