### PR TITLE
add data url support

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ const loadContent = require("./lib/load-content")
 const processContent = require("./lib/process-content")
 const parseStatements = require("./lib/parse-statements")
 const assignLayerNames = require("./lib/assign-layer-names")
+const dataURL = require("./lib/data-url")
 
 function AtImport(options) {
   options = {
@@ -290,6 +291,14 @@ function AtImport(options) {
       }
 
       function resolveImportId(result, stmt, options, state) {
+        if (dataURL.isValid(stmt.uri)) {
+          return loadImportContent(result, stmt, stmt.uri, options, state).then(
+            result => {
+              stmt.children = result
+            }
+          )
+        }
+
         const atRule = stmt.node
         let sourceFile
         if (atRule.source?.input?.file) {

--- a/lib/data-url.js
+++ b/lib/data-url.js
@@ -8,7 +8,7 @@ function isValid(url) {
 
 function contents(url) {
   // "data:text/css;base64,".length == 21
-  return atob(url.slice(21))
+  return Buffer.from(url.slice(21), "base64").toString()
 }
 
 module.exports = {

--- a/lib/data-url.js
+++ b/lib/data-url.js
@@ -7,7 +7,7 @@ function isValid(url) {
 }
 
 function contents(url) {
-  // "data:text/css;base64,".length == 21
+  // "data:text/css;base64,".length === 21
   return Buffer.from(url.slice(21), "base64").toString()
 }
 

--- a/lib/data-url.js
+++ b/lib/data-url.js
@@ -1,0 +1,17 @@
+"use strict"
+
+const dataURLRegexp = /^data:text\/css;base64,/i
+
+function isValid(url) {
+  return dataURLRegexp.test(url)
+}
+
+function contents(url) {
+  // "data:text/css;base64,".length == 21
+  return atob(url.slice(21))
+}
+
+module.exports = {
+  isValid,
+  contents,
+}

--- a/lib/load-content.js
+++ b/lib/load-content.js
@@ -1,5 +1,12 @@
 "use strict"
 
 const readCache = require("read-cache")
+const dataURL = require("./data-url")
 
-module.exports = filename => readCache(filename, "utf-8")
+module.exports = filename => {
+  if (dataURL.isValid(filename)) {
+    return dataURL.contents(filename)
+  }
+
+  return readCache(filename, "utf-8")
+}

--- a/test/data-url.js
+++ b/test/data-url.js
@@ -1,0 +1,8 @@
+"use strict"
+// external tooling
+const test = require("ava")
+
+// internal tooling
+const checkFixture = require("./helpers/check-fixture")
+
+test("should inline data urls", checkFixture, "data-url")

--- a/test/fixtures/data-url.css
+++ b/test/fixtures/data-url.css
@@ -1,0 +1,2 @@
+@import url(data:text/css;base64,QGltcG9ydCB1cmwoZGF0YTp0ZXh0L2NzcztiYXNlNjQsY0NCN0lHTnZiRzl5T2lCbmNtVmxianNnZlE9PSk7CgpwIHsgY29sb3I6IGJsdWU7IH0K);
+@import url("DATA:TEXT/CSS;BASE64,QGltcG9ydCB1cmwoZGF0YTp0ZXh0L2NzcztiYXNlNjQsY0NCN0lHTnZiRzl5T2lCbmNtVmxianNnZlE9PSk7CgpwIHsgY29sb3I6IGJsdWU7IH0K") layer(foo) (min-width: 320px);

--- a/test/fixtures/data-url.css
+++ b/test/fixtures/data-url.css
@@ -1,2 +1,6 @@
 @import url(data:text/css;base64,QGltcG9ydCB1cmwoZGF0YTp0ZXh0L2NzcztiYXNlNjQsY0NCN0lHTnZiRzl5T2lCbmNtVmxianNnZlE9PSk7CgpwIHsgY29sb3I6IGJsdWU7IH0K);
 @import url("DATA:TEXT/CSS;BASE64,QGltcG9ydCB1cmwoZGF0YTp0ZXh0L2NzcztiYXNlNjQsY0NCN0lHTnZiRzl5T2lCbmNtVmxianNnZlE9PSk7CgpwIHsgY29sb3I6IGJsdWU7IH0K") layer(foo) (min-width: 320px);
+
+/* Mixed imports: */
+@import url(data:text/css;base64,QGltcG9ydCB1cmwoZm9vLmNzcyk7CgpwIHsKICBjb2xvcjogYmx1ZTsKfQo=);
+@import url(data-url.css);

--- a/test/fixtures/data-url.expected.css
+++ b/test/fixtures/data-url.expected.css
@@ -12,3 +12,13 @@ p { color: green; } } }
  @layer foo {
 
 p { color: blue; } } }
+
+/* Mixed imports: */
+
+foo{}
+
+p {
+  color: blue;
+}
+
+p { color: pink; }

--- a/test/fixtures/data-url.expected.css
+++ b/test/fixtures/data-url.expected.css
@@ -1,0 +1,14 @@
+p { color: green; }
+
+p { color: blue; }
+
+@media (min-width: 320px) {
+
+ @layer foo {
+p { color: green; } } }
+
+@media (min-width: 320px) {
+
+ @layer foo {
+
+p { color: blue; } } }

--- a/test/fixtures/imports/data-url.css
+++ b/test/fixtures/imports/data-url.css
@@ -1,0 +1,1 @@
+@import url("DATA:text/CSS;BASE64,cCB7IGNvbG9yOiBwaW5rOyB9");


### PR DESCRIPTION
This change adds support for :

```css
@import url(data:text/css;base64,...)
```

_Before this change a data url would throw an error, so this is not something that is being used today by users of this plugin._

As far as I can tell the change required is minimal and everything just works.
- media queries
- at layer
- sourcemaps
- nesting multiple imports within data urls

---------

I don't this is useful on its own.
Authors should not be base64 encoding CSS source code and storing this in `@import` urls.

It can however be useful for other plugins that have non-standard interactions with `@import`.

Another plugin that does want to provide extra features can choose to store as base64 instead of inlining.

This keeps the source valid with all `@import` rules before anything else and all in the correct order.

---------

An alternative approach to this is that other plugins use the file system.
Instead of inlining they can store the contents in a file and update the `@import` rules so they each is fully standard CSS and everything points to a local file.

_Both approaches have merit and I don't have a strong preference between them._