### PR TITLE
add parsing support for supports conditions

### DIFF
--- a/lib/parse-statements.js
+++ b/lib/parse-statements.js
@@ -113,59 +113,97 @@ function parseImport(result, atRule) {
   const params = valueParser(atRule.params).nodes
   const stmt = {
     type: "import",
+    uri: "",
+    fullUri: "",
     node: atRule,
     media: [],
     layer: [],
+    supports: [],
   }
 
-  // prettier-ignore
-  if (
-    !params.length ||
-    (
-      params[0].type !== "string" ||
-      !params[0].value
-    ) &&
-    (
-      params[0].type !== "function" ||
-      params[0].value !== "url" ||
-      !params[0].nodes.length ||
-      !params[0].nodes[0].value
-    )
-  ) {
-    return result.warn(`Unable to find uri in '${  atRule.toString()  }'`, {
+  for (let i = 0; i < params.length; i++) {
+    const node = params[i]
+
+    if (node.type === "space" || node.type === "comment") continue
+
+    if (node.type === "string") {
+      if (stmt.uri) {
+        return result.warn(`Multiple url's in '${atRule.toString()}'`, {
+          node: atRule,
+        })
+      }
+
+      if (!node.value) {
+        return result.warn(`Unable to find uri in '${atRule.toString()}'`, {
+          node: atRule,
+        })
+      }
+
+      stmt.uri = node.value
+      stmt.fullUri = stringify(node)
+      continue
+    }
+
+    if (node.type === "function" && /^url$/i.test(node.value)) {
+      if (stmt.uri) {
+        return result.warn(`Multiple url's in '${atRule.toString()}'`, {
+          node: atRule,
+        })
+      }
+
+      if (!node.nodes?.[0]?.value) {
+        return result.warn(`Unable to find uri in '${atRule.toString()}'`, {
+          node: atRule,
+        })
+      }
+
+      stmt.uri = node.nodes[0].value
+      stmt.fullUri = stringify(node)
+      continue
+    }
+
+    if (!stmt.uri) {
+      return result.warn(`Unable to find uri in '${atRule.toString()}'`, {
+        node: atRule,
+      })
+    }
+
+    if (
+      (node.type === "word" || node.type === "function") &&
+      /^layer$/i.test(node.value)
+    ) {
+      if (node.nodes) {
+        stmt.layer = [stringify(node.nodes)]
+      } else {
+        stmt.layer = [""]
+      }
+
+      continue
+    }
+
+    if (node.type === "function" && /^supports$/i.test(node.value)) {
+      stmt.supports = [stringify(node.nodes)]
+
+      continue
+    }
+
+    stmt.media = split(params, i)
+    break
+  }
+
+  if (!stmt.uri) {
+    return result.warn(`Unable to find uri in '${atRule.toString()}'`, {
       node: atRule,
     })
   }
 
-  if (params[0].type === "string") stmt.uri = params[0].value
-  else stmt.uri = params[0].nodes[0].value
-  stmt.fullUri = stringify(params[0])
-
-  let remainder = params
-  if (remainder.length > 2) {
-    if (
-      (remainder[2].type === "word" || remainder[2].type === "function") &&
-      remainder[2].value === "layer"
-    ) {
-      if (remainder[1].type !== "space") {
-        return result.warn("Invalid import layer statement", { node: atRule })
+  if (stmt.supports.length) {
+    return result.warn(
+      `Supports conditions are not implemented at this time.`,
+      {
+        node: atRule,
       }
-
-      if (remainder[2].nodes) {
-        stmt.layer = [stringify(remainder[2].nodes)]
-      } else {
-        stmt.layer = [""]
-      }
-      remainder = remainder.slice(2)
-    }
-  }
-
-  if (remainder.length > 2) {
-    if (remainder[1].type !== "space") {
-      return result.warn("Invalid import media statement", { node: atRule })
-    }
-
-    stmt.media = split(remainder, 2)
+    )
   }
 
   return stmt

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   },
   "devDependencies": {
     "ava": "^5.0.0",
+    "c8": "^8.0.0",
     "eslint": "^8.2.0",
     "eslint-config-problems": "^7.0.0",
     "eslint-plugin-prettier": "^4.0.0",
@@ -42,7 +43,7 @@
     "ci": "eslint . && ava",
     "lint": "eslint . --fix",
     "pretest": "npm run lint",
-    "test": "ava"
+    "test": "c8 ava"
   },
   "eslintConfig": {
     "extends": "eslint-config-problems",


### PR DESCRIPTION
- added parsing support for `supports` conditions
- rewrote the import statement parser
- added coverage checks with `c8`

---------

Fully implementing supports conditions will require a fairly large refactor and the codebase is already very complex.

I would like to first do a few refactors.
This is one of them.

Initially the parsing algorithm was a simple split.
Look for anything that could be a uri, everything after is a `media` condition.

With `layer` and `supports` something more flexible is needed.

Any `supports` conditions will currently give errors.

This is already a behavior change.
Before this PR `supports` conditions would be treated as if they were `media` conditions, which is always incorrect.

Both behaviors are broken but after this change CSS authors will receive more meaningful feedback.