### PR TITLE
Error on embedded imports in data urls

### DIFF
--- a/lib/parse-styles.js
+++ b/lib/parse-styles.js
@@ -98,7 +98,7 @@ async function resolveImportId(result, stmt, options, state, postcss) {
     // we set the conditions to `not all`.
     stmt.media = ["not all"]
     result.warn(
-      `Unable to import '${stmt.uri}' from a stylesheet embedded in a data url`,
+      `Unable to import '${stmt.uri}' from a stylesheet which is embedded in a data url`,
       {
         node: stmt.node,
       }

--- a/lib/parse-styles.js
+++ b/lib/parse-styles.js
@@ -93,15 +93,9 @@ async function resolveImportId(result, stmt, options, state, postcss) {
     return
   } else if (dataURL.isValid(stmt.from.slice(-1))) {
     // Data urls can't be used as a base url to resolve imports.
-    // Skip inlining and warn.
-    stmt.children = []
-    result.warn(
-      `Unable to import '${stmt.uri}' from a stylesheet that is embedded in a data url`,
-      {
-        node: stmt.node,
-      }
+    throw stmt.node.error(
+      `Unable to import '${stmt.uri}' from a stylesheet that is embedded in a data url`
     )
-    return
   }
 
   const atRule = stmt.node

--- a/lib/parse-styles.js
+++ b/lib/parse-styles.js
@@ -98,7 +98,7 @@ async function resolveImportId(result, stmt, options, state, postcss) {
     // we set the conditions to `not all`.
     stmt.media = ["not all"]
     result.warn(
-      `Unable to import '${stmt.uri}' from a stylesheet which is embedded in a data url`,
+      `Unable to import '${stmt.uri}' from a stylesheet that is embedded in a data url`,
       {
         node: stmt.node,
       }

--- a/lib/parse-styles.js
+++ b/lib/parse-styles.js
@@ -97,6 +97,12 @@ async function resolveImportId(result, stmt, options, state, postcss) {
     // and the current statement doesn't have a data url
     // we set the conditions to `not all`.
     stmt.media = ["not all"]
+    result.warn(
+      `Unable to import '${stmt.uri}' from a stylesheet embedded in a data url`,
+      {
+        node: stmt.node,
+      }
+    )
     return
   }
 

--- a/lib/parse-styles.js
+++ b/lib/parse-styles.js
@@ -92,11 +92,9 @@ async function resolveImportId(result, stmt, options, state, postcss) {
 
     return
   } else if (dataURL.isValid(stmt.from.slice(-1))) {
-    // Data urls can't be used a base url to resolve imports.
-    // When the parent statement has a data url
-    // and the current statement doesn't have a data url
-    // we set the conditions to `not all`.
-    stmt.media = ["not all"]
+    // Data urls can't be used as a base url to resolve imports.
+    // Skip inlining and warn.
+    stmt.children = []
     result.warn(
       `Unable to import '${stmt.uri}' from a stylesheet that is embedded in a data url`,
       {

--- a/lib/parse-styles.js
+++ b/lib/parse-styles.js
@@ -94,7 +94,9 @@ async function resolveImportId(result, stmt, options, state, postcss) {
   } else if (dataURL.isValid(stmt.from.slice(-1))) {
     // Data urls can't be used a base url to resolve imports.
     // When the parent statement has a data url
-    // and the current statement doesn't have a data url we ignore the statement.
+    // and the current statement doesn't have a data url
+    // we set the conditions to `not all`.
+    stmt.media = ["not all"]
     return
   }
 

--- a/test/data-url.js
+++ b/test/data-url.js
@@ -6,5 +6,5 @@ const test = require("ava")
 const checkFixture = require("./helpers/check-fixture")
 
 test("should inline data urls", checkFixture, "data-url", null, null, [
-  `Unable to import 'foo.css' from a stylesheet embedded in a data url`,
+  `Unable to import 'foo.css' from a stylesheet which is embedded in a data url`,
 ])

--- a/test/data-url.js
+++ b/test/data-url.js
@@ -6,5 +6,5 @@ const test = require("ava")
 const checkFixture = require("./helpers/check-fixture")
 
 test("should inline data urls", checkFixture, "data-url", null, null, [
-  `Unable to import 'foo.css' from a stylesheet which is embedded in a data url`,
+  `Unable to import 'foo.css' from a stylesheet that is embedded in a data url`,
 ])

--- a/test/data-url.js
+++ b/test/data-url.js
@@ -1,10 +1,27 @@
 "use strict"
 // external tooling
 const test = require("ava")
+const postcss = require("postcss")
+
+// plugin
+const atImport = require("..")
 
 // internal tooling
 const checkFixture = require("./helpers/check-fixture")
 
-test("should inline data urls", checkFixture, "data-url", null, null, [
-  `Unable to import 'foo.css' from a stylesheet that is embedded in a data url`,
-])
+test("should inline data urls", checkFixture, "data-url")
+
+test("should error on relative urls from stylesheets in data urls", t => {
+  return postcss()
+    .use(atImport())
+    .process(
+      "@import url(data:text/css;base64,QGltcG9ydCB1cmwoZm9vLmNzcyk7CgpwIHsKICBjb2xvcjogYmx1ZTsKfQo=);",
+      { from: undefined }
+    )
+    .catch(error =>
+      t.regex(
+        error.message,
+        /Unable to import '(?:.*?)' from a stylesheet that is embedded in a data url/
+      )
+    )
+})

--- a/test/data-url.js
+++ b/test/data-url.js
@@ -5,4 +5,6 @@ const test = require("ava")
 // internal tooling
 const checkFixture = require("./helpers/check-fixture")
 
-test("should inline data urls", checkFixture, "data-url")
+test("should inline data urls", checkFixture, "data-url", null, null, [
+  `Unable to import 'foo.css' from a stylesheet embedded in a data url`,
+])

--- a/test/fixtures/data-url.css
+++ b/test/fixtures/data-url.css
@@ -2,7 +2,6 @@
 @import url("DATA:TEXT/CSS;BASE64,QGltcG9ydCB1cmwoZGF0YTp0ZXh0L2NzcztiYXNlNjQsY0NCN0lHTnZiRzl5T2lCbmNtVmxianNnZlE9PSk7CgpwIHsgY29sb3I6IGJsdWU7IH0K") layer(foo) (min-width: 320px);
 
 /* Mixed imports: */
-@import url(data:text/css;base64,QGltcG9ydCB1cmwoZm9vLmNzcyk7CgpwIHsKICBjb2xvcjogYmx1ZTsKfQo=);
 @import url(data-url.css);
 
 /* url encoded: */

--- a/test/fixtures/data-url.expected.css
+++ b/test/fixtures/data-url.expected.css
@@ -15,10 +15,6 @@ p { color: blue; } } }
 
 /* Mixed imports: */
 
-p {
-  color: blue;
-}
-
 p { color: pink; }
 
 /* url encoded: */

--- a/test/fixtures/data-url.expected.css
+++ b/test/fixtures/data-url.expected.css
@@ -1,4 +1,4 @@
-@import url(foo.css);p { color: green; }p { color: blue; }@media (min-width: 320px){@layer foo{
+@import url(foo.css) not all;p { color: green; }p { color: blue; }@media (min-width: 320px){@layer foo{
 p { color: green; } } }@media (min-width: 320px){@layer foo{
 
 p { color: blue; } } }/* Mixed imports: */p {

--- a/test/fixtures/data-url.expected.css
+++ b/test/fixtures/data-url.expected.css
@@ -1,6 +1,28 @@
-@import url(foo.css) not all;p { color: green; }p { color: blue; }@media (min-width: 320px){@layer foo{
-p { color: green; } } }@media (min-width: 320px){@layer foo{
+p { color: green; }
 
-p { color: blue; } } }/* Mixed imports: */p {
+p { color: blue; }
+
+@media (min-width: 320px) {
+
+ @layer foo {
+p { color: green; } } }
+
+@media (min-width: 320px) {
+
+ @layer foo {
+
+p { color: blue; } } }
+
+/* Mixed imports: */
+
+p {
   color: blue;
-}p { color: pink; }/* url encoded: */bar { color: green }bar { color: pink }
+}
+
+p { color: pink; }
+
+/* url encoded: */
+
+bar { color: green }
+
+bar { color: pink }


### PR DESCRIPTION
The current code prevents further inlining of embedded imports but it doesn't stop a browser from possible loading and applying it.

~~Adding `not all` has the intended effect.~~

Setting `stmt.children = []` prevents inlining and removes the `@import` statement.