### PR TITLE
Allow urls that contain fragments, fixes #560

### DIFF
--- a/lib/parse-styles.js
+++ b/lib/parse-styles.js
@@ -227,11 +227,6 @@ function isProcessableURL(uri) {
   try {
     // needs a base to parse properly
     const url = new URL(uri, "https://example.com")
-
-    if (url.hash) {
-      return false
-    }
-
     if (url.search) {
       return false
     }

--- a/test/fixtures/filter-ignore.css
+++ b/test/fixtures/filter-ignore.css
@@ -13,5 +13,4 @@
 @import url('//css');
 @import url(//css);
 @import url('foo.css?query=string');
-@import url('foo.css#hash');
 content{}

--- a/test/fixtures/filter-ignore.expected.css
+++ b/test/fixtures/filter-ignore.expected.css
@@ -14,7 +14,6 @@
 @import url('//css');
 @import url(//css);
 @import url('foo.css?query=string');
-@import url('foo.css#hash');
 @media (min-width: 25em){
 ignore{}
 }

--- a/test/fixtures/imports/modules/subpath/a.css
+++ b/test/fixtures/imports/modules/subpath/a.css
@@ -1,0 +1,3 @@
+.foo {
+  color: green;
+}

--- a/test/fixtures/imports/modules/subpath/package.json
+++ b/test/fixtures/imports/modules/subpath/package.json
@@ -1,0 +1,6 @@
+{
+  "style": "style.css",
+  "imports": {
+    "#a.css": "./a.css"
+  }
+}

--- a/test/fixtures/imports/modules/subpath/style.css
+++ b/test/fixtures/imports/modules/subpath/style.css
@@ -1,0 +1,1 @@
+@import '#a.css';

--- a/test/fixtures/subpath.css
+++ b/test/fixtures/subpath.css
@@ -1,0 +1,1 @@
+@import "subpath";

--- a/test/fixtures/subpath.expected.css
+++ b/test/fixtures/subpath.expected.css
@@ -1,0 +1,3 @@
+.foo {
+  color: green;
+}

--- a/test/resolve.js
+++ b/test/resolve.js
@@ -1,6 +1,8 @@
 "use strict"
 // external tooling
 const test = require("ava")
+const fs = require("fs")
+const path = require("path")
 
 // internal tooling
 const checkFixture = require("./helpers/check-fixture")
@@ -71,4 +73,25 @@ test(
   "resolve-custom-modules",
   { path: null, addModulesDirectories: ["shared_modules"] },
   { from: "test/fixtures/imports/foo.css" },
+)
+
+test(
+  "should resolve modules with node subpath imports with a custom resolver",
+  checkFixture,
+  "subpath",
+  {
+    resolve: (id, basedir) => {
+      // see: https://nodejs.org/api/packages.html#subpath-imports
+      if (id.startsWith("#")) {
+        const pkgJSON = JSON.parse(
+          fs.readFileSync(path.join(basedir, "package.json")),
+        )
+
+        return path.join(basedir, pkgJSON.imports[id])
+      }
+
+      return id
+    },
+    path: "test/fixtures/imports/modules",
+  },
 )


### PR DESCRIPTION
The intention behind ignoring urls with a fragment was to make the plugin more correct.
The thinking at the time was that these are never valid imports for a filesystem.
With nodejs subpath imports that assumption is incorrect.

